### PR TITLE
Raise default similarity threshold to 0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ The repository now ships a PAM module (`libpam_chissu.so`) that authenticates Li
 - Build the shared library with `cargo build --release -p pam-chissu` (or `cargo test -p pam-chissu` during development).
 - Copy `target/release/libpam_chissu.so` into your PAM module directory (for example `sudo install -m 0644 target/release/libpam_chissu.so /lib/security/libpam_chissu.so`) and reference it from `/etc/pam.d/<service>` with `auth sufficient libpam_chissu.so`. The build no longer emits the historical `libpam_chissuauth.so` symlink, so there is a single canonical shared object to package.
 - Configure the module via `/etc/chissu-pam/config.toml` (preferred) or `/usr/local/etc/chissu-pam/config.toml`. Each file is optional; when both are absent, the module falls back to:
-  - `similarity_threshold = 0.7`
+  - `similarity_threshold = 0.9`
   - `capture_timeout_secs = 5`
   - `frame_interval_millis = 500`
   - `video_device = "/dev/video0"`
@@ -244,7 +244,7 @@ The first file that exists wins for each key; CLI flags or environment variables
 | `warmup_frames`                                  | Number of frames to discard before saving.                                                 |
 | `embedding_store_dir`                           | Directory for encrypted embedding files (`/var/lib/chissu-pam/models`).                   |
 | `landmark_model` / `encoder_model`               | Paths to the dlib weights (overrideable via `DLIB_LANDMARK_MODEL` / `DLIB_ENCODER_MODEL`). |
-| `similarity_threshold`                           | PAM acceptance threshold (default `0.7`).                                                  |
+| `similarity_threshold`                           | PAM acceptance threshold (default `0.9`).                                                  |
 | `capture_timeout_secs` / `frame_interval_millis` | Live-auth capture timing knobs.                                                            |
 | `jitters`                                        | Number of random jitters applied when encoding embeddings.                                 |
 | `require_secret_service`                         | Fail fast when the Secret Service helper cannot obtain a key.                              |

--- a/crates/chissu-config/src/lib.rs
+++ b/crates/chissu-config/src/lib.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 
 pub const PRIMARY_CONFIG_PATH: &str = "/etc/chissu-pam/config.toml";
 pub const SECONDARY_CONFIG_PATH: &str = "/usr/local/etc/chissu-pam/config.toml";
-pub const DEFAULT_SIMILARITY_THRESHOLD: f64 = 0.7;
+pub const DEFAULT_SIMILARITY_THRESHOLD: f64 = 0.9;
 pub const DEFAULT_TIMEOUT_SECS: u64 = 5;
 pub const DEFAULT_INTERVAL_MILLIS: u64 = 500;
 pub const DEFAULT_VIDEO_DEVICE: &str = "/dev/video0";

--- a/docs/pam-auth.md
+++ b/docs/pam-auth.md
@@ -39,7 +39,7 @@ sudo install -m 0644 target/release/libpam_chissu.so /lib/security/libpam_chissu
 The module reads configuration from `/etc/chissu-pam/config.toml`. If the file is absent it falls back to `/usr/local/etc/chissu-pam/config.toml`. Both files are optional—defaults are used when neither exists. Developers adding new keys or validations must update `crates/chissu-config`, which is the shared loader used by both the PAM module and `chissu-cli`. Available keys:
 
 ```toml
-similarity_threshold = 0.75     # Float, default 0.7
+similarity_threshold = 0.75     # Float, default 0.9
 capture_timeout_secs = 8        # Integer seconds, default 5
 frame_interval_millis = 300     # Integer ms between samples, default 500
 video_device = "/dev/video2"   # String, default "/dev/video0"


### PR DESCRIPTION
## Summary
- raise the built-in similarity_threshold default to 0.9 in the shared config loader
- document the new PAM default in README.md and docs/pam-auth.md

## Testing
- `CARGO_HOME="$(pwd)/.cargo-home" cargo test --workspace`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b163899b0832184a029683dcceeb1)