### PR TITLE
Enhance privilege drop handling in Secret Service helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,8 @@ To roll back just the PAM wiring, run `sudo scripts/install-chissu.sh --uninstal
 
 Successful hydration emits `Recovered session environment from logind for user 'alice': session=3 tty=tty2 seat=seat0 type=wayland ...` in syslog. If you instead see `No active logind session for user 'alice' (tty hint tty2)` the PAM stack will fall back to passwords until that desktop session is running/unlocked.
 
+Desktop unlock services such as `cinnamon-screensaver` may invoke PAM from a context that cannot perform `setuid`/`setgid` again. When that happens, `pam_chissu` now logs the failing privilege-drop stage and intentionally falls back to password authentication instead of aborting the entire unlock flow.
+
 ## Workspace layout
 
 ```
@@ -314,7 +316,7 @@ The repository now ships a PAM module (`libpam_chissu.so`) that authenticates Li
   - `require_secret_service = false`
 - Syslog (facility `AUTHPRIV`) records start, success, timeout, and error events. Review output with `journalctl -t pam_chissu` or `journalctl SYSLOG_IDENTIFIER=pam_chissu`.
 - Interactive PAM conversations mirror those events on the terminal: successful matches trigger a `PAM_TEXT_INFO` banner, while retries and failures emit `PAM_ERROR_MSG` guidance ("stay in frame", "no embeddings", etc.) so operators see immediate feedback even without tailing syslog.
-- Before opening the camera the module now forks a short-lived helper that switches to the PAM target user (`setuid`) and talks to the user's GNOME Secret Service session over D-Bus. The helper returns a JSON payload containing either the AES-GCM embedding key, a "missing" status, or a structured error. The parent logs the outcome and (a) continues capture when the key was returned, (b) surfaces the "no embeddings" flow when the key is missing, or (c) returns `PAM_IGNORE` when Secret Service is locked/unreachable so downstream modules can continue handling the login.
+- Before opening the camera the module now forks a short-lived helper that switches to the PAM target user (`setuid`) and talks to the user's GNOME Secret Service session over D-Bus. The helper returns a JSON payload containing either the AES-GCM embedding key, a "missing" status, or a structured error. The parent logs the outcome and (a) continues capture when the key was returned, (b) surfaces the "no embeddings" flow when the key is missing, or (c) returns `PAM_IGNORE` when Secret Service is locked/unreachable or privilege-dropping is denied so downstream modules can continue handling the login.
 - Use `chissu-cli keyring check` to verify that Secret Service is reachable for the current user before wiring the PAM module into a stack. The command exits `0` on success, emits structured JSON when `--json` is supplied, and surfaces the underlying keyring error when the probe fails. Set `require_secret_service = true` to enforce the helper inside PAM; it defaults to `false` so you can opt in once the desktop session exposes Secret Service. Store a 32-byte AES-GCM embedding key (Base64-encoded) under `service=chissu-pam` and `user=<pam user>` so the helper can unlock embedding files during authentication.
 - The module honours `DLIB_LANDMARK_MODEL` and `DLIB_ENCODER_MODEL` (or config entries with the same names) to locate dlib model files.
 

--- a/crates/pam-chissu/src/lib.rs
+++ b/crates/pam-chissu/src/lib.rs
@@ -22,7 +22,7 @@ use chissu_face_core::secret_service::default_service_name;
 use image::{Rgb, RgbImage};
 use libc::{c_int, free};
 use logind::LogindInspector;
-use nix::unistd::User;
+use nix::unistd::{getegid, geteuid, User};
 use pam_sys::{
     get_item, get_user, ConvClosure, PamConversation, PamHandle, PamItemType, PamMessage,
     PamMessageStyle, PamResponse, PamReturnCode,
@@ -376,6 +376,7 @@ fn authenticate_user(
 
     if config.require_secret_service {
         helper_env = prepare_helper_env(request, logger);
+        log_privilege_drop_context(&request.user, logger);
         match run_secret_service_helper(&request.user, config.capture_timeout, helper_env.as_ref())
         {
             Ok(HelperResponse::Key(key_bytes)) => {
@@ -401,11 +402,7 @@ fn authenticate_user(
             Err(SecretHelperError::SecretServiceUnavailable(message)) => {
                 return Err(AuthError::SecretServiceUnavailable(message));
             }
-            Err(SecretHelperError::IpcFailure(message)) => {
-                return Err(AuthError::Pam(format!(
-                    "Secret Service helper failed: {message}"
-                )));
-            }
+            Err(err) => return Err(map_secret_helper_error(err)),
         }
     } else {
         logger.info("Secret Service probe disabled via configuration; continuing without check");
@@ -627,14 +624,7 @@ fn load_embedding_store(
                         ));
                         return Err(AuthError::SecretServiceUnavailable(message));
                     }
-                    Err(SecretHelperError::SecretServiceUnavailable(message)) => {
-                        return Err(AuthError::SecretServiceUnavailable(message));
-                    }
-                    Err(SecretHelperError::IpcFailure(message)) => {
-                        return Err(AuthError::Pam(format!(
-                            "Secret Service helper failed: {message}"
-                        )));
-                    }
+                    Err(err) => return Err(map_secret_helper_error(err)),
                 }
             }
             Err(err) => return Err(AuthError::Core(err)),
@@ -651,6 +641,40 @@ fn notify_secret_service_unavailable(
         "Secret Service unavailable; skipping face authentication: {reason}"
     ));
     messenger.send_error_msg(logger, SECRET_SERVICE_FALLBACK_PROMPT);
+}
+
+fn map_secret_helper_error(err: SecretHelperError) -> AuthError {
+    match err {
+        SecretHelperError::SecretServiceUnavailable(message) => {
+            AuthError::SecretServiceUnavailable(message)
+        }
+        SecretHelperError::PrivilegeDrop(failure) if failure.is_eperm() => {
+            AuthError::SecretServiceUnavailable(format!(
+                "Secret Service helper {}",
+                failure.message()
+            ))
+        }
+        SecretHelperError::PrivilegeDrop(failure) => {
+            AuthError::Pam(format!("Secret Service helper {}", failure.message()))
+        }
+        SecretHelperError::IpcFailure(message) => {
+            AuthError::Pam(format!("Secret Service helper failed: {message}"))
+        }
+    }
+}
+
+fn log_privilege_drop_context(user: &str, logger: &mut PamLogger) {
+    let Ok(Some(info)) = User::from_name(user) else {
+        return;
+    };
+
+    let current_uid = geteuid();
+    let current_gid = getegid();
+    if current_uid == info.uid && current_gid == info.gid {
+        logger.info(&format!(
+            "Secret Service helper privilege drop skipped for user '{user}': already running as target uid/gid"
+        ));
+    }
 }
 
 fn load_config() -> PamResult<ResolvedConfigWithSource> {
@@ -828,6 +852,7 @@ unsafe fn get_service_name(pamh: *mut PamHandle) -> PamResult<String> {
 mod tests {
     use super::*;
     use chissu_face_core::faces::BoundingBox;
+    use secret_helper::{HelperError, PrivilegeDropStage};
     use serial_test::serial;
     use std::ffi::CStr;
     use std::io::Write;
@@ -1017,6 +1042,40 @@ mod tests {
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].0, PamMessageStyle::ERROR_MSG);
         assert_eq!(entries[0].1, SECRET_SERVICE_FALLBACK_PROMPT);
+    }
+
+    #[test]
+    fn map_secret_helper_error_treats_eperm_as_secret_service_unavailable() {
+        let err = map_secret_helper_error(HelperError::PrivilegeDrop(
+            secret_helper::PrivilegeDropFailure::new(
+                PrivilegeDropStage::Setuid,
+                "privilege drop failed at setuid: EPERM: Operation not permitted".into(),
+                Some(libc::EPERM),
+            ),
+        ));
+        assert!(
+            matches!(err, AuthError::SecretServiceUnavailable(message) if message.contains("setuid"))
+        );
+    }
+
+    #[test]
+    fn map_secret_helper_error_keeps_non_eperm_privilege_drop_fatal() {
+        let err = map_secret_helper_error(HelperError::PrivilegeDrop(
+            secret_helper::PrivilegeDropFailure::new(
+                PrivilegeDropStage::Setgid,
+                "privilege drop failed at setgid: EINVAL".into(),
+                Some(libc::EINVAL),
+            ),
+        ));
+        assert!(matches!(err, AuthError::Pam(message) if message.contains("setgid")));
+    }
+
+    #[test]
+    fn map_secret_helper_error_keeps_ipc_failures_fatal() {
+        let err = map_secret_helper_error(HelperError::IpcFailure(
+            "helper produced no response".into(),
+        ));
+        assert!(matches!(err, AuthError::Pam(message) if message.contains("no response")));
     }
 
     #[test]

--- a/crates/pam-chissu/src/secret_helper.rs
+++ b/crates/pam-chissu/src/secret_helper.rs
@@ -11,7 +11,9 @@ use chissu_face_core::secret_service::{
 };
 use nix::sys::signal::{kill, Signal};
 use nix::sys::wait::{waitpid, WaitStatus};
-use nix::unistd::{fork, initgroups, setgid, setuid, ForkResult, Pid, User};
+use nix::unistd::{
+    fork, getegid, geteuid, initgroups, setgid, setuid, ForkResult, Gid, Pid, Uid, User,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug)]
@@ -23,7 +25,55 @@ pub enum HelperResponse {
 #[derive(Debug)]
 pub enum HelperError {
     SecretServiceUnavailable(String),
+    PrivilegeDrop(PrivilegeDropFailure),
     IpcFailure(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrivilegeDropFailure {
+    stage: PrivilegeDropStage,
+    message: String,
+    errno: Option<i32>,
+}
+
+impl PrivilegeDropFailure {
+    pub(crate) fn new(stage: PrivilegeDropStage, message: String, errno: Option<i32>) -> Self {
+        Self {
+            stage,
+            message,
+            errno,
+        }
+    }
+
+    pub fn stage(&self) -> PrivilegeDropStage {
+        self.stage
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    pub fn errno(&self) -> Option<i32> {
+        self.errno
+    }
+
+    pub fn is_eperm(&self) -> bool {
+        self.errno == Some(libc::EPERM)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PrivilegeDropStage {
+    Initgroups,
+    Setgid,
+    Setuid,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PrivilegeDropPlan {
+    Skip,
+    Switch,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -87,10 +137,15 @@ fn child_entry(
         apply_env_overrides(overrides);
     }
 
-    if let Err(message) = drop_privileges(&user) {
+    if let Err(failure) = drop_privileges(&user) {
         emit_and_exit(
             &mut stream,
-            HelperWireMessage::error(HelperWireErrorKind::IpcFailure, &message),
+            HelperWireMessage::Error {
+                kind: HelperWireErrorKind::PrivilegeDrop,
+                message: failure.message().into(),
+                stage: Some(failure.stage()),
+                errno: failure.errno(),
+            },
         );
     }
 
@@ -119,6 +174,8 @@ fn child_entry(
                 HelperWireMessage::Error {
                     kind: HelperWireErrorKind::SecretServiceUnavailable,
                     message: err.to_string(),
+                    stage: None,
+                    errno: None,
                 },
             );
         }
@@ -128,19 +185,59 @@ fn child_entry(
                 HelperWireMessage::Error {
                     kind: HelperWireErrorKind::InvalidKey,
                     message: reason,
+                    stage: None,
+                    errno: None,
                 },
             );
         }
     }
 }
 
-fn drop_privileges(user: &User) -> Result<(), String> {
-    let name = CString::new(user.name.clone())
-        .map_err(|err| format!("failed to prepare username for initgroups: {err}"))?;
-    initgroups(&name, user.gid).map_err(|err| err.to_string())?;
-    setgid(user.gid).map_err(|err| err.to_string())?;
-    setuid(user.uid).map_err(|err| err.to_string())?;
+fn drop_privileges(user: &User) -> Result<(), PrivilegeDropFailure> {
+    if privilege_drop_plan(user.uid, user.gid, geteuid(), getegid()) == PrivilegeDropPlan::Skip {
+        return Ok(());
+    }
+
+    let name = CString::new(user.name.clone()).map_err(|err| {
+        PrivilegeDropFailure::new(PrivilegeDropStage::Initgroups, err.to_string(), None)
+    })?;
+    if geteuid().is_root() {
+        initgroups(&name, user.gid).map_err(|err| {
+            PrivilegeDropFailure::new(
+                PrivilegeDropStage::Initgroups,
+                format!("privilege drop failed at initgroups: {err}"),
+                Some(err as i32),
+            )
+        })?;
+    }
+    setgid(user.gid).map_err(|err| {
+        PrivilegeDropFailure::new(
+            PrivilegeDropStage::Setgid,
+            format!("privilege drop failed at setgid: {err}"),
+            (err as i32 != 0).then_some(err as i32),
+        )
+    })?;
+    setuid(user.uid).map_err(|err| {
+        PrivilegeDropFailure::new(
+            PrivilegeDropStage::Setuid,
+            format!("privilege drop failed at setuid: {err}"),
+            (err as i32 != 0).then_some(err as i32),
+        )
+    })?;
     Ok(())
+}
+
+fn privilege_drop_plan(
+    target_uid: Uid,
+    target_gid: Gid,
+    current_uid: Uid,
+    current_gid: Gid,
+) -> PrivilegeDropPlan {
+    if current_uid == target_uid && current_gid == target_gid {
+        PrivilegeDropPlan::Skip
+    } else {
+        PrivilegeDropPlan::Switch
+    }
 }
 
 fn emit_and_exit(stream: &mut UnixStream, payload: HelperWireMessage) -> ! {
@@ -237,7 +334,18 @@ fn translate_message(msg: HelperWireMessage) -> Result<HelperResponse, HelperErr
         HelperWireMessage::Error {
             kind: HelperWireErrorKind::SecretServiceUnavailable,
             message,
+            ..
         } => Err(HelperError::SecretServiceUnavailable(message)),
+        HelperWireMessage::Error {
+            kind: HelperWireErrorKind::PrivilegeDrop,
+            message,
+            stage,
+            errno,
+        } => Err(HelperError::PrivilegeDrop(PrivilegeDropFailure::new(
+            stage.unwrap_or(PrivilegeDropStage::Setuid),
+            message,
+            errno,
+        ))),
         HelperWireMessage::Error { message, .. } => Err(HelperError::IpcFailure(message)),
     }
 }
@@ -255,22 +363,18 @@ enum HelperWireMessage {
     Error {
         kind: HelperWireErrorKind,
         message: String,
+        #[serde(default)]
+        stage: Option<PrivilegeDropStage>,
+        #[serde(default)]
+        errno: Option<i32>,
     },
-}
-
-impl HelperWireMessage {
-    fn error(kind: HelperWireErrorKind, message: &str) -> Self {
-        HelperWireMessage::Error {
-            kind,
-            message: message.into(),
-        }
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 enum HelperWireErrorKind {
     SecretServiceUnavailable,
+    PrivilegeDrop,
     InvalidKey,
     IpcFailure,
 }
@@ -309,12 +413,54 @@ mod tests {
         let err = translate_message(HelperWireMessage::Error {
             kind: HelperWireErrorKind::SecretServiceUnavailable,
             message: "locked".into(),
+            stage: None,
+            errno: None,
         })
         .unwrap_err();
         match err {
             HelperError::SecretServiceUnavailable(message) => assert_eq!(message, "locked"),
             _ => panic!("expected secret service error"),
         }
+    }
+
+    #[test]
+    fn translate_message_maps_privilege_drop_error() {
+        let err = translate_message(HelperWireMessage::Error {
+            kind: HelperWireErrorKind::PrivilegeDrop,
+            message: "privilege drop failed at setuid: EPERM: Operation not permitted".into(),
+            stage: Some(PrivilegeDropStage::Setuid),
+            errno: Some(libc::EPERM),
+        })
+        .unwrap_err();
+        match err {
+            HelperError::PrivilegeDrop(failure) => {
+                assert_eq!(failure.stage(), PrivilegeDropStage::Setuid);
+                assert!(failure.is_eperm());
+            }
+            _ => panic!("expected privilege drop error"),
+        }
+    }
+
+    #[test]
+    fn privilege_drop_plan_skips_when_already_target_user() {
+        let plan = privilege_drop_plan(
+            Uid::from_raw(1000),
+            Gid::from_raw(1000),
+            Uid::from_raw(1000),
+            Gid::from_raw(1000),
+        );
+        assert_eq!(plan, PrivilegeDropPlan::Skip);
+    }
+
+    #[test]
+    fn privilege_drop_plan_switches_when_identity_differs() {
+        let plan = privilege_drop_plan(
+            Uid::from_raw(1000),
+            Gid::from_raw(1000),
+            Uid::from_raw(0),
+            Gid::from_raw(0),
+        );
+        assert_eq!(plan, PrivilegeDropPlan::Switch);
     }
 
     #[test]


### PR DESCRIPTION
Improve handling of privilege drop failures in the Secret Service helper. The changes ensure that when privilege dropping is denied, the system logs the context and falls back to password authentication instead of aborting the unlock flow. Additionally, error mapping for privilege drop failures has been refined to provide clearer feedback.

#19