### PR TITLE
Add polkit-agent-helper troubleshooting guide and session-aware Secret Service handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,10 +280,13 @@ Run a quick, non-destructive diagnostic to confirm PAM + enrollment prerequisite
 
 ```bash
 chissu-cli doctor            # human-readable
+chissu-cli doctor --polkit   # include polkit-agent-helper sandbox checks
 chissu-cli --json doctor | jq
 ```
 
 Checks include config discovery/parse, video device access, embedding store permissions, dlib model readability, Secret Service availability, the PAM module location, and whether `/etc/pam.d/*` references `pam_chissu`. Exit code is `0` only when every check passes; warnings (e.g., both config files present) or failures return `1` with details per check.
+
+Add `--polkit` when debugging 1Password or other polkit-based desktop prompts. The extra checks inspect `polkit-agent-helper@.service` and report sandbox settings that can hide `/run/user/<uid>/bus` or the configured camera device; see [Polkit Agent Helper Troubleshooting](docs/users-guide/polkit-agent-helper-troubleshooting.md) for the matching systemd drop-in guidance.
 
 ### Enroll with live capture (`chissu-cli enroll`)
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ To roll back just the PAM wiring, run `sudo scripts/install-chissu.sh --uninstal
 
 ### Secret Service + logind troubleshooting
 
-`pam_chissu` now hydrates missing `$DISPLAY`, `$DBUS_SESSION_BUS_ADDRESS`, and `$XDG_RUNTIME_DIR` variables from systemd-logind whenever `require_secret_service = true`. This matters for PAM clients like polkit-1 (1Password unlock dialogs, GNOME Software updates, etc.) that invoke authentication without inheriting your desktop environment. Use these checks whenever the journal logs `Secret Service unavailable; skipping face authentication` or `No active logind session`:
+`pam_chissu` now hydrates missing or unusable `$DBUS_SESSION_BUS_ADDRESS`, `$XDG_RUNTIME_DIR`, `$DISPLAY`, and `$WAYLAND_DISPLAY` variables from systemd-logind whenever `require_secret_service = true`. This matters for PAM clients like polkit-1 (1Password unlock dialogs, GNOME Software updates, etc.) that invoke authentication without inheriting your desktop environment. The default `secret_service_session = "auto"` detects X11 vs Wayland from logind's `Type`/`Display`; set it to `"x11"` or `"wayland"` only when an unusual desktop stack needs an explicit override. Use these checks whenever the journal logs `Secret Service unavailable; skipping face authentication` or `No active logind session`:
 
 1. **Confirm the session exists**
 
@@ -229,17 +229,22 @@ To roll back just the PAM wiring, run `sudo scripts/install-chissu.sh --uninstal
    loginctl show-session <id> -p Display -p Type -p TTY -p Remote -p State
    ```
 
-   The helper copies `Display` (e.g., `:0` or `wayland-0`) plus the runtime seat info before forking.
+   The helper uses `Type` plus `Display` to decide whether to export `DISPLAY` for X11 or `WAYLAND_DISPLAY` for Wayland before forking.
 
 3. **Verify the runtime directory**
 
    ```bash
    loginctl show-user $(id -u $USER) -p RuntimePath
+   test -S /run/user/$(id -u)/bus
    ```
 
-   A valid runtime dir allows the helper to synthesize `unix:path=$XDG_RUNTIME_DIR/bus` for Secret Service.
+   A valid runtime dir allows the helper to synthesize `unix:path=$XDG_RUNTIME_DIR/bus` for Secret Service. This session bus is the important path on Wayland-only systems; otherwise libdbus may fall back to X11 autolaunch and fail with messages such as `Unable to autolaunch a dbus-daemon without a $DISPLAY for X11`.
 
-Successful hydration emits `Recovered session environment from logind for user 'alice': session=3 tty=tty2 seat=seat0 type=wayland ...` in syslog. If you instead see `No active logind session for user 'alice' (tty hint tty2)` the PAM stack will fall back to passwords until that desktop session is running/unlocked.
+Successful hydration emits `Recovered Secret Service session environment from logind for user 'alice': session=3 tty=tty2 seat=seat0 type=wayland ... configured_mode=auto selected_mode=wayland applied=...` in syslog. If you instead see `No active logind session for user 'alice' (tty hint tty2)` the PAM stack will fall back to passwords until that desktop session is running/unlocked.
+
+If the recovered address still fails with `Failed to connect to socket /run/user/<uid>/bus: Permission denied`, the helper logs a DBus preflight line with its `uid/euid/gid/egid` plus the runtime directory and bus socket owner/mode. That usually indicates the PAM caller is isolated from the user's runtime bus by the service manager or a security profile, not that X11/Wayland detection failed.
+
+Ubuntu 26.04 no longer offers an X11-based GNOME session in typical installs, so Wayland-only behavior is expected there; see [Ubuntu Weekly Recipe 908](https://gihyo.jp/admin/serial/01/ubuntu-recipe/0908). Keep `secret_service_session = "auto"` unless logind reports misleading session data.
 
 Desktop unlock services such as `cinnamon-screensaver` may invoke PAM from a context that cannot perform `setuid`/`setgid` again. When that happens, `pam_chissu` now logs the failing privilege-drop stage and intentionally falls back to password authentication instead of aborting the entire unlock flow.
 
@@ -346,6 +351,7 @@ The first file that exists wins for each key; CLI flags or environment variables
 | `capture_timeout_secs` / `frame_interval_millis` | Live-auth capture timing knobs.                                                            |
 | `jitters`                                        | Number of random jitters applied when encoding embeddings.                                 |
 | `require_secret_service`                         | Fail fast when the Secret Service helper cannot obtain a key.                              |
+| `secret_service_session`                         | Secret Service helper session mode: `auto`, `x11`, or `wayland` (default `auto`).          |
 
 For CLI operations, `chissu-config` also honours `CHISSU_PAM_STORE_DIR` for embedding storage overrides plus any immediate CLI flags. After editing the TOML file, re-run `chissu-cli keyring check` and a quick `chissu-cli capture --json` to verify the new settings.
 

--- a/build/package/assets/etc/chissu-pam/config.toml
+++ b/build/package/assets/etc/chissu-pam/config.toml
@@ -10,3 +10,5 @@ embedding_store_dir = "/var/lib/chissu-pam/embeddings"
 landmark_model = "/var/lib/chissu-pam/dlib-models/shape_predictor_68_face_landmarks.dat"
 encoder_model = "/var/lib/chissu-pam/dlib-models/dlib_face_recognition_resnet_model_v1.dat"
 require_secret_service = true
+# Secret Service session environment mode: "auto", "x11", or "wayland".
+secret_service_session = "auto"

--- a/build/package/debian/Dockerfile
+++ b/build/package/debian/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     RUSTUP_HOME=/usr/local/rustup \
     PATH=/usr/local/cargo/bin:${PATH}
 
-RUN apt-get update -qq && apt-get install -y --no-install-recommends \
+RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends \
     build-essential \
     pkg-config \
     libclang-dev \

--- a/crates/chissu-cli/src/cli.rs
+++ b/crates/chissu-cli/src/cli.rs
@@ -37,7 +37,14 @@ pub enum Commands {
     #[command(subcommand)]
     Keyring(KeyringCommands),
     /// Run environment diagnostics for PAM and enrollment prerequisites
-    Doctor,
+    Doctor(DoctorArgs),
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct DoctorArgs {
+    /// Include polkit-agent-helper systemd sandbox diagnostics
+    #[arg(long)]
+    pub polkit: bool,
 }
 
 #[derive(Debug, Subcommand)]

--- a/crates/chissu-cli/src/commands/doctor.rs
+++ b/crates/chissu-cli/src/commands/doctor.rs
@@ -1,30 +1,33 @@
 use std::any::Any;
 use std::process::ExitCode;
 
-use crate::cli::OutputMode;
+use crate::cli::{DoctorArgs, OutputMode};
 use crate::commands::CommandHandler;
-use crate::doctor::{self, DoctorOutcome};
+use crate::doctor::{self, DoctorOptions, DoctorOutcome};
 use crate::errors::AppResult;
 use crate::output::render_doctor;
 
-type DoctorRunner = dyn Fn() -> AppResult<DoctorOutcome> + Send + Sync;
+type DoctorRunner = dyn Fn(DoctorOptions) -> AppResult<DoctorOutcome> + Send + Sync;
 type DoctorRenderer = dyn Fn(&DoctorOutcome, OutputMode) -> AppResult<()> + Send + Sync;
 
 pub struct DoctorHandler {
+    args: DoctorArgs,
     run_doctor: Box<DoctorRunner>,
     render: Box<DoctorRenderer>,
 }
 
 impl DoctorHandler {
-    pub fn new() -> Self {
-        Self::with_dependencies(doctor::run_doctor, render_doctor)
+    pub fn new(args: DoctorArgs) -> Self {
+        Self::with_dependencies(args, doctor::run_doctor_with_options, render_doctor)
     }
 
     pub fn with_dependencies(
-        run_doctor: impl Fn() -> AppResult<DoctorOutcome> + Send + Sync + 'static,
+        args: DoctorArgs,
+        run_doctor: impl Fn(DoctorOptions) -> AppResult<DoctorOutcome> + Send + Sync + 'static,
         render: impl Fn(&DoctorOutcome, OutputMode) -> AppResult<()> + Send + Sync + 'static,
     ) -> Self {
         Self {
+            args,
             run_doctor: Box::new(run_doctor),
             render: Box::new(render),
         }
@@ -33,13 +36,15 @@ impl DoctorHandler {
 
 impl Default for DoctorHandler {
     fn default() -> Self {
-        Self::new()
+        Self::new(DoctorArgs { polkit: false })
     }
 }
 
 impl CommandHandler for DoctorHandler {
     fn execute(&self, mode: OutputMode, _verbose: bool) -> AppResult<ExitCode> {
-        let outcome = (self.run_doctor)()?;
+        let outcome = (self.run_doctor)(DoctorOptions {
+            include_polkit: self.args.polkit,
+        })?;
         (self.render)(&outcome, mode)?;
         let exit = if outcome.ok {
             ExitCode::SUCCESS

--- a/crates/chissu-cli/src/commands/mod.rs
+++ b/crates/chissu-cli/src/commands/mod.rs
@@ -27,7 +27,7 @@ impl From<Commands> for Box<dyn CommandHandler> {
             Commands::Enroll(args) => Box::new(EnrollHandler::new(args)),
             Commands::Faces(cmd) => Box::new(FacesHandler::new(cmd)),
             Commands::Keyring(cmd) => Box::new(KeyringHandler::new(cmd)),
-            Commands::Doctor => Box::new(DoctorHandler::new()),
+            Commands::Doctor(args) => Box::new(DoctorHandler::new(args)),
         }
     }
 }

--- a/crates/chissu-cli/src/doctor.rs
+++ b/crates/chissu-cli/src/doctor.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use chissu_config::{
     self, ConfigError, ResolvedConfig, ResolvedConfigWithSource, PRIMARY_CONFIG_PATH,
@@ -24,6 +25,11 @@ const CHECK_ENCODER_MODEL: &str = "encoder_model";
 const CHECK_SECRET_SERVICE: &str = "secret_service";
 const CHECK_PAM_MODULE: &str = "pam_module";
 const CHECK_PAM_STACK: &str = "pam_stack";
+const CHECK_POLKIT_HELPER_UNIT: &str = "polkit_helper_unit";
+const CHECK_POLKIT_SESSION_BUS_ACCESS: &str = "polkit_session_bus_access";
+const CHECK_POLKIT_VIDEO_DEVICE_ACCESS: &str = "polkit_video_device_access";
+const POLKIT_HELPER_UNIT: &str = "polkit-agent-helper@.service";
+const POLKIT_GUIDE: &str = "docs/users-guide/polkit-agent-helper-troubleshooting.md";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -48,6 +54,26 @@ pub struct DoctorCheck {
 pub struct DoctorOutcome {
     pub ok: bool,
     pub checks: Vec<DoctorCheck>,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DoctorOptions {
+    pub include_polkit: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DoctorProfile {
+    Default,
+    Polkit,
+}
+
+impl DoctorOptions {
+    fn includes(self, profile: DoctorProfile) -> bool {
+        match profile {
+            DoctorProfile::Default => true,
+            DoctorProfile::Polkit => self.include_polkit,
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -88,10 +114,11 @@ impl DeviceOpener for RealDeviceOpener {
     }
 }
 
-pub struct DoctorContext<P, D> {
+pub struct DoctorContext<P, D, I = RealPolkitInspector> {
     pub paths: DoctorPaths,
     pub secret_service_probe: P,
     pub device_opener: D,
+    pub polkit_inspector: I,
     pub fallback_config: ResolvedConfig,
 }
 
@@ -101,46 +128,334 @@ impl Default for DoctorContext<KeyringSecretServiceProbe, RealDeviceOpener> {
             paths: DoctorPaths::default(),
             secret_service_probe: KeyringSecretServiceProbe,
             device_opener: RealDeviceOpener,
+            polkit_inspector: RealPolkitInspector,
             fallback_config: ResolvedConfig::default(),
         }
     }
 }
 
-pub fn run_doctor() -> AppResult<DoctorOutcome> {
-    let ctx = DoctorContext::default();
-    run_doctor_with(&ctx)
+struct DoctorServices<'a, P, D, I> {
+    paths: &'a DoctorPaths,
+    secret_service_probe: &'a P,
+    device_opener: &'a D,
+    polkit_inspector: &'a I,
+    fallback_config: &'a ResolvedConfig,
 }
 
-pub fn run_doctor_with<P, D>(ctx: &DoctorContext<P, D>) -> AppResult<DoctorOutcome>
+impl<'a, P, D, I> From<&'a DoctorContext<P, D, I>> for DoctorServices<'a, P, D, I> {
+    fn from(ctx: &'a DoctorContext<P, D, I>) -> Self {
+        Self {
+            paths: &ctx.paths,
+            secret_service_probe: &ctx.secret_service_probe,
+            device_opener: &ctx.device_opener,
+            polkit_inspector: &ctx.polkit_inspector,
+            fallback_config: &ctx.fallback_config,
+        }
+    }
+}
+
+#[derive(Default)]
+struct DoctorState {
+    resolved: Option<ResolvedConfigWithSource>,
+    referenced_modules: Vec<PathBuf>,
+    polkit_unit: Option<Result<PolkitUnitSettings, String>>,
+    checks: Vec<DoctorCheck>,
+}
+
+impl DoctorState {
+    fn push(&mut self, check: DoctorCheck) {
+        self.checks.push(check);
+    }
+
+    fn resolved(&self) -> &ResolvedConfigWithSource {
+        self.resolved
+            .as_ref()
+            .expect("config check must run before checks that need resolved config")
+    }
+}
+
+struct DoctorCheckSpec<P, D, I> {
+    name: &'static str,
+    profiles: &'static [DoctorProfile],
+    run: fn(&mut DoctorState, &DoctorServices<'_, P, D, I>),
+}
+
+impl<P, D, I> DoctorCheckSpec<P, D, I> {
+    fn enabled(&self, options: DoctorOptions) -> bool {
+        self.profiles
+            .iter()
+            .any(|profile| options.includes(*profile))
+    }
+}
+
+pub fn run_doctor() -> AppResult<DoctorOutcome> {
+    run_doctor_with_options(DoctorOptions::default())
+}
+
+pub fn run_doctor_with_options(options: DoctorOptions) -> AppResult<DoctorOutcome> {
+    let ctx = DoctorContext::default();
+    run_doctor_with_options_and_context(&ctx, options)
+}
+
+pub fn run_doctor_with<P, D, I>(ctx: &DoctorContext<P, D, I>) -> AppResult<DoctorOutcome>
 where
     P: SecretServiceProbe,
     D: DeviceOpener,
+    I: PolkitInspector,
 {
-    let (config_check, resolved) = check_config(&ctx.paths, &ctx.fallback_config);
+    run_doctor_with_options_and_context(ctx, DoctorOptions::default())
+}
 
-    let mut checks = vec![config_check];
+pub fn run_doctor_with_options_and_context<P, D, I>(
+    ctx: &DoctorContext<P, D, I>,
+    options: DoctorOptions,
+) -> AppResult<DoctorOutcome>
+where
+    P: SecretServiceProbe,
+    D: DeviceOpener,
+    I: PolkitInspector,
+{
+    let services = DoctorServices::from(ctx);
+    let mut state = DoctorState::default();
+    for spec in check_registry() {
+        if spec.enabled(options) {
+            debug_assert!(!spec.name.is_empty());
+            (spec.run)(&mut state, &services);
+        }
+    }
 
-    checks.push(check_video_device(&resolved, &ctx.device_opener));
-    checks.push(check_embedding_dir(&resolved));
-    checks.push(check_model(
+    let ok = state.checks.iter().all(|c| c.status == CheckStatus::Pass);
+
+    Ok(DoctorOutcome {
+        ok,
+        checks: state.checks,
+    })
+}
+
+#[derive(Clone, Copy)]
+pub struct RealPolkitInspector;
+
+pub trait PolkitInspector {
+    fn inspect(&self) -> Result<PolkitUnitSettings, String>;
+}
+
+impl PolkitInspector for RealPolkitInspector {
+    fn inspect(&self) -> Result<PolkitUnitSettings, String> {
+        inspect_polkit_unit()
+    }
+}
+
+const DEFAULT_PROFILE: &[DoctorProfile] = &[DoctorProfile::Default];
+const POLKIT_PROFILE: &[DoctorProfile] = &[DoctorProfile::Polkit];
+
+fn check_registry<P, D, I>() -> [DoctorCheckSpec<P, D, I>; 11]
+where
+    P: SecretServiceProbe,
+    D: DeviceOpener,
+    I: PolkitInspector,
+{
+    [
+        DoctorCheckSpec {
+            name: CHECK_CONFIG,
+            profiles: DEFAULT_PROFILE,
+            run: run_config_check,
+        },
+        DoctorCheckSpec {
+            name: CHECK_VIDEO_DEVICE,
+            profiles: DEFAULT_PROFILE,
+            run: run_video_device_check,
+        },
+        DoctorCheckSpec {
+            name: CHECK_EMBEDDING_DIR,
+            profiles: DEFAULT_PROFILE,
+            run: run_embedding_dir_check,
+        },
+        DoctorCheckSpec {
+            name: CHECK_LANDMARK_MODEL,
+            profiles: DEFAULT_PROFILE,
+            run: run_landmark_model_check,
+        },
+        DoctorCheckSpec {
+            name: CHECK_ENCODER_MODEL,
+            profiles: DEFAULT_PROFILE,
+            run: run_encoder_model_check,
+        },
+        DoctorCheckSpec {
+            name: CHECK_SECRET_SERVICE,
+            profiles: DEFAULT_PROFILE,
+            run: run_secret_service_check,
+        },
+        DoctorCheckSpec {
+            name: CHECK_PAM_STACK,
+            profiles: DEFAULT_PROFILE,
+            run: run_pam_stack_check,
+        },
+        DoctorCheckSpec {
+            name: CHECK_PAM_MODULE,
+            profiles: DEFAULT_PROFILE,
+            run: run_pam_module_check,
+        },
+        DoctorCheckSpec {
+            name: CHECK_POLKIT_HELPER_UNIT,
+            profiles: POLKIT_PROFILE,
+            run: run_polkit_helper_unit_check,
+        },
+        DoctorCheckSpec {
+            name: CHECK_POLKIT_SESSION_BUS_ACCESS,
+            profiles: POLKIT_PROFILE,
+            run: run_polkit_session_bus_access_check,
+        },
+        DoctorCheckSpec {
+            name: CHECK_POLKIT_VIDEO_DEVICE_ACCESS,
+            profiles: POLKIT_PROFILE,
+            run: run_polkit_video_device_access_check,
+        },
+    ]
+}
+
+fn run_config_check<P, D, I>(state: &mut DoctorState, services: &DoctorServices<'_, P, D, I>) {
+    let (check, resolved) = check_config(services.paths, services.fallback_config);
+    state.resolved = Some(resolved);
+    state.push(check);
+}
+
+fn run_video_device_check<P, D, I>(state: &mut DoctorState, services: &DoctorServices<'_, P, D, I>)
+where
+    D: DeviceOpener,
+{
+    state.push(check_video_device(state.resolved(), services.device_opener));
+}
+
+fn run_embedding_dir_check<P, D, I>(
+    state: &mut DoctorState,
+    _services: &DoctorServices<'_, P, D, I>,
+) {
+    state.push(check_embedding_dir(state.resolved()));
+}
+
+fn run_landmark_model_check<P, D, I>(
+    state: &mut DoctorState,
+    _services: &DoctorServices<'_, P, D, I>,
+) {
+    state.push(check_model(
         CHECK_LANDMARK_MODEL,
-        resolved.resolved.landmark_model.as_ref(),
+        state.resolved().resolved.landmark_model.as_ref(),
     ));
-    checks.push(check_model(
+}
+
+fn run_encoder_model_check<P, D, I>(
+    state: &mut DoctorState,
+    _services: &DoctorServices<'_, P, D, I>,
+) {
+    state.push(check_model(
         CHECK_ENCODER_MODEL,
-        resolved.resolved.encoder_model.as_ref(),
+        state.resolved().resolved.encoder_model.as_ref(),
     ));
-    checks.push(check_secret_service(&ctx.secret_service_probe));
-    let (pam_stack_check, referenced_modules) = check_pam_stack(&ctx.paths.pamd_dir);
-    checks.push(pam_stack_check);
-    checks.push(check_pam_module(
-        referenced_modules.as_slice(),
-        &ctx.paths.pam_module_paths,
+}
+
+fn run_secret_service_check<P, D, I>(
+    state: &mut DoctorState,
+    services: &DoctorServices<'_, P, D, I>,
+) where
+    P: SecretServiceProbe,
+{
+    state.push(check_secret_service(services.secret_service_probe));
+}
+
+fn run_pam_stack_check<P, D, I>(state: &mut DoctorState, services: &DoctorServices<'_, P, D, I>) {
+    let (check, referenced_modules) = check_pam_stack(&services.paths.pamd_dir);
+    state.referenced_modules = referenced_modules;
+    state.push(check);
+}
+
+fn run_pam_module_check<P, D, I>(state: &mut DoctorState, services: &DoctorServices<'_, P, D, I>) {
+    state.push(check_pam_module(
+        state.referenced_modules.as_slice(),
+        &services.paths.pam_module_paths,
     ));
+}
 
-    let ok = checks.iter().all(|c| c.status == CheckStatus::Pass);
+fn run_polkit_helper_unit_check<P, D, I>(
+    state: &mut DoctorState,
+    services: &DoctorServices<'_, P, D, I>,
+) where
+    I: PolkitInspector,
+{
+    let check = match polkit_unit_result(state, services) {
+        Ok(settings) => check_polkit_helper_unit(&settings),
+        Err(message) => DoctorCheck {
+            name: CHECK_POLKIT_HELPER_UNIT.into(),
+            status: CheckStatus::Warn,
+            message: format!(
+                "Could not inspect {POLKIT_HELPER_UNIT}: {message}; see {POLKIT_GUIDE}"
+            ),
+            path: None,
+            device: None,
+        },
+    };
+    state.push(check);
+}
 
-    Ok(DoctorOutcome { ok, checks })
+fn run_polkit_session_bus_access_check<P, D, I>(
+    state: &mut DoctorState,
+    services: &DoctorServices<'_, P, D, I>,
+) where
+    I: PolkitInspector,
+{
+    let check = match polkit_unit_result(state, services) {
+        Ok(settings) => check_polkit_session_bus_access(&settings),
+        Err(_) => DoctorCheck {
+            name: CHECK_POLKIT_SESSION_BUS_ACCESS.into(),
+            status: CheckStatus::Warn,
+            message: format!(
+                "Skipped session bus sandbox check because {POLKIT_HELPER_UNIT} could not be inspected"
+            ),
+            path: Some("/run/user".into()),
+            device: None,
+        },
+    };
+    state.push(check);
+}
+
+fn run_polkit_video_device_access_check<P, D, I>(
+    state: &mut DoctorState,
+    services: &DoctorServices<'_, P, D, I>,
+) where
+    I: PolkitInspector,
+{
+    let device = display_device(&DeviceLocator::from_option(Some(
+        state.resolved().resolved.video_device.clone(),
+    )));
+    let check = match polkit_unit_result(state, services) {
+        Ok(settings) => check_polkit_video_device_access(&settings, &device),
+        Err(_) => DoctorCheck {
+            name: CHECK_POLKIT_VIDEO_DEVICE_ACCESS.into(),
+            status: CheckStatus::Warn,
+            message: format!(
+                "Skipped video device sandbox check because {POLKIT_HELPER_UNIT} could not be inspected"
+            ),
+            path: None,
+            device: Some(device),
+        },
+    };
+    state.push(check);
+}
+
+fn polkit_unit_result<P, D, I>(
+    state: &mut DoctorState,
+    services: &DoctorServices<'_, P, D, I>,
+) -> Result<PolkitUnitSettings, String>
+where
+    I: PolkitInspector,
+{
+    if state.polkit_unit.is_none() {
+        state.polkit_unit = Some(services.polkit_inspector.inspect());
+    }
+    state
+        .polkit_unit
+        .as_ref()
+        .expect("polkit unit inspection result initialized")
+        .clone()
 }
 
 fn check_config(
@@ -517,6 +832,272 @@ fn check_pam_stack(pamd_dir: &Path) -> (DoctorCheck, Vec<PathBuf>) {
     }
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PolkitUnitSettings {
+    load_state: Option<String>,
+    protect_home: Option<String>,
+    bind_read_only_paths: Vec<String>,
+    bind_paths: Vec<String>,
+    private_devices: Option<String>,
+    device_policy: Option<String>,
+    device_allow: Vec<String>,
+    source: String,
+}
+
+fn check_polkit_helper_unit(settings: &PolkitUnitSettings) -> DoctorCheck {
+    if polkit_unit_unavailable(settings) {
+        return DoctorCheck {
+            name: CHECK_POLKIT_HELPER_UNIT.into(),
+            status: CheckStatus::Warn,
+            message: format!(
+                "{POLKIT_HELPER_UNIT} load state is {}; polkit prompts may use a different helper on this system",
+                settings.load_state.as_deref().unwrap_or("unknown")
+            ),
+            path: None,
+            device: None,
+        };
+    }
+
+    DoctorCheck {
+        name: CHECK_POLKIT_HELPER_UNIT.into(),
+        status: CheckStatus::Pass,
+        message: format!("Inspected {POLKIT_HELPER_UNIT} via {}", settings.source),
+        path: None,
+        device: None,
+    }
+}
+
+fn check_polkit_session_bus_access(settings: &PolkitUnitSettings) -> DoctorCheck {
+    if polkit_unit_unavailable(settings) {
+        return DoctorCheck {
+            name: CHECK_POLKIT_SESSION_BUS_ACCESS.into(),
+            status: CheckStatus::Warn,
+            message: format!(
+                "Skipped session bus sandbox check because {POLKIT_HELPER_UNIT} is not loaded"
+            ),
+            path: Some("/run/user".into()),
+            device: None,
+        };
+    }
+
+    let protect_home = settings.protect_home.as_deref().unwrap_or("unset");
+    let hides_runtime = matches!(protect_home, "yes" | "read-only" | "tmpfs");
+    let has_runtime_bind = contains_bound_path(&settings.bind_read_only_paths, "/run/user")
+        || contains_bound_path(&settings.bind_paths, "/run/user");
+
+    if hides_runtime && !has_runtime_bind {
+        return DoctorCheck {
+            name: CHECK_POLKIT_SESSION_BUS_ACCESS.into(),
+            status: CheckStatus::Fail,
+            message: format!(
+                "{POLKIT_HELPER_UNIT} sets ProtectHome={protect_home} without BindReadOnlyPaths=/run/user; Secret Service bus access may fail. See {POLKIT_GUIDE}"
+            ),
+            path: Some("/run/user".into()),
+            device: None,
+        };
+    }
+
+    DoctorCheck {
+        name: CHECK_POLKIT_SESSION_BUS_ACCESS.into(),
+        status: CheckStatus::Pass,
+        message: format!(
+            "{POLKIT_HELPER_UNIT} exposes /run/user for recovered Secret Service session bus access"
+        ),
+        path: Some("/run/user".into()),
+        device: None,
+    }
+}
+
+fn check_polkit_video_device_access(settings: &PolkitUnitSettings, device: &str) -> DoctorCheck {
+    if polkit_unit_unavailable(settings) {
+        return DoctorCheck {
+            name: CHECK_POLKIT_VIDEO_DEVICE_ACCESS.into(),
+            status: CheckStatus::Warn,
+            message: format!(
+                "Skipped video device sandbox check because {POLKIT_HELPER_UNIT} is not loaded"
+            ),
+            path: None,
+            device: Some(device.into()),
+        };
+    }
+
+    let mut failures = Vec::new();
+    if matches!(settings.private_devices.as_deref(), Some("yes" | "true"))
+        && !contains_bound_path(&settings.bind_paths, device)
+    {
+        failures.push(format!("PrivateDevices=yes without BindPaths={device}"));
+    }
+    if matches!(settings.device_policy.as_deref(), Some("strict" | "closed"))
+        && !device_allow_contains_rw(&settings.device_allow, device)
+    {
+        failures.push(format!(
+            "DevicePolicy={} without DeviceAllow={device} rw",
+            settings.device_policy.as_deref().unwrap_or("strict")
+        ));
+    }
+
+    if failures.is_empty() {
+        DoctorCheck {
+            name: CHECK_POLKIT_VIDEO_DEVICE_ACCESS.into(),
+            status: CheckStatus::Pass,
+            message: format!("{POLKIT_HELPER_UNIT} allows configured video device {device}"),
+            path: None,
+            device: Some(device.into()),
+        }
+    } else {
+        DoctorCheck {
+            name: CHECK_POLKIT_VIDEO_DEVICE_ACCESS.into(),
+            status: CheckStatus::Fail,
+            message: format!(
+                "{}; polkit camera capture may fail. See {POLKIT_GUIDE}",
+                failures.join("; ")
+            ),
+            path: None,
+            device: Some(device.into()),
+        }
+    }
+}
+
+fn inspect_polkit_unit() -> Result<PolkitUnitSettings, String> {
+    let show = Command::new("systemctl")
+        .args([
+            "show",
+            POLKIT_HELPER_UNIT,
+            "-p",
+            "LoadState",
+            "-p",
+            "ProtectHome",
+            "-p",
+            "BindReadOnlyPaths",
+            "-p",
+            "BindPaths",
+            "-p",
+            "PrivateDevices",
+            "-p",
+            "DevicePolicy",
+            "-p",
+            "DeviceAllow",
+            "--no-pager",
+        ])
+        .output();
+
+    match show {
+        Ok(output) if output.status.success() => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            return Ok(parse_systemctl_show(&stdout));
+        }
+        Ok(_) | Err(_) => {}
+    }
+
+    let cat = Command::new("systemctl")
+        .args(["cat", POLKIT_HELPER_UNIT])
+        .output()
+        .map_err(|err| err.to_string())?;
+    if !cat.status.success() {
+        return Err(String::from_utf8_lossy(&cat.stderr).trim().to_string());
+    }
+    Ok(parse_systemctl_cat(&String::from_utf8_lossy(&cat.stdout)))
+}
+
+fn parse_systemctl_show(contents: &str) -> PolkitUnitSettings {
+    let mut settings = PolkitUnitSettings {
+        source: "systemctl show".into(),
+        ..PolkitUnitSettings::default()
+    };
+    for line in contents.lines() {
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        apply_polkit_setting(&mut settings, key.trim(), value.trim());
+    }
+    settings
+}
+
+fn polkit_unit_unavailable(settings: &PolkitUnitSettings) -> bool {
+    matches!(settings.load_state.as_deref(), Some("not-found" | "masked"))
+}
+
+fn parse_systemctl_cat(contents: &str) -> PolkitUnitSettings {
+    let mut settings = PolkitUnitSettings {
+        source: "systemctl cat".into(),
+        ..PolkitUnitSettings::default()
+    };
+    for line in contents.lines() {
+        let active = line.split('#').next().map(str::trim).unwrap_or("");
+        if active.is_empty() || active.starts_with('[') {
+            continue;
+        }
+        let Some((key, value)) = active.split_once('=') else {
+            continue;
+        };
+        apply_polkit_setting(&mut settings, key.trim(), value.trim());
+    }
+    settings
+}
+
+fn apply_polkit_setting(settings: &mut PolkitUnitSettings, key: &str, value: &str) {
+    match key {
+        "LoadState" => settings.load_state = non_empty(value),
+        "ProtectHome" => settings.protect_home = non_empty(value),
+        "BindReadOnlyPaths" => apply_systemd_list(&mut settings.bind_read_only_paths, value),
+        "BindPaths" => apply_systemd_list(&mut settings.bind_paths, value),
+        "PrivateDevices" => settings.private_devices = non_empty(value),
+        "DevicePolicy" => settings.device_policy = non_empty(value),
+        "DeviceAllow" => {
+            if value.is_empty() {
+                settings.device_allow.clear();
+            } else {
+                settings.device_allow.push(value.into());
+            }
+        }
+        _ => {}
+    }
+}
+
+fn non_empty(value: &str) -> Option<String> {
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.into())
+    }
+}
+
+fn split_systemd_list(value: &str) -> Vec<String> {
+    value
+        .split_whitespace()
+        .filter(|item| !item.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn apply_systemd_list(target: &mut Vec<String>, value: &str) {
+    if value.is_empty() {
+        target.clear();
+    } else {
+        target.extend(split_systemd_list(value));
+    }
+}
+
+fn contains_bound_path(entries: &[String], needle: &str) -> bool {
+    entries.iter().any(|entry| {
+        let source = entry.split(':').next().unwrap_or(entry);
+        source == needle || needle.starts_with(&format!("{source}/"))
+    })
+}
+
+fn device_allow_contains_rw(entries: &[String], device: &str) -> bool {
+    entries.iter().any(|entry| {
+        let parts = entry.split_whitespace().collect::<Vec<_>>();
+        parts.iter().enumerate().any(|(index, part)| {
+            *part == device
+                && parts[index + 1..]
+                    .iter()
+                    .take_while(|candidate| !candidate.starts_with('/'))
+                    .any(|candidate| candidate.contains('r') && candidate.contains('w'))
+        })
+    })
+}
+
 fn display_paths(paths: &[PathBuf]) -> String {
     paths
         .iter()
@@ -626,6 +1207,17 @@ mod tests {
         }
     }
 
+    #[derive(Clone)]
+    struct StubPolkitInspector {
+        result: Result<PolkitUnitSettings, String>,
+    }
+
+    impl PolkitInspector for StubPolkitInspector {
+        fn inspect(&self) -> Result<PolkitUnitSettings, String> {
+            self.result.clone()
+        }
+    }
+
     fn base_paths(tmp: &Path) -> DoctorPaths {
         DoctorPaths {
             config_paths: vec![tmp.join("config.toml")],
@@ -675,9 +1267,32 @@ mod tests {
             paths,
             secret_service_probe: probe,
             device_opener: StubDeviceOpener { ok: device_ok },
+            polkit_inspector: StubPolkitInspector {
+                result: Err("not used".into()),
+            },
             fallback_config: fallback,
         };
         run_doctor_with(&ctx).unwrap()
+    }
+
+    fn doctor_with_options(
+        paths: DoctorPaths,
+        probe: StubProbe,
+        device_ok: bool,
+        fallback: ResolvedConfig,
+        options: DoctorOptions,
+        polkit_result: Result<PolkitUnitSettings, String>,
+    ) -> DoctorOutcome {
+        let ctx = DoctorContext {
+            paths,
+            secret_service_probe: probe,
+            device_opener: StubDeviceOpener { ok: device_ok },
+            polkit_inspector: StubPolkitInspector {
+                result: polkit_result,
+            },
+            fallback_config: fallback,
+        };
+        run_doctor_with_options_and_context(&ctx, options).unwrap()
     }
 
     fn status<'a>(checks: &'a [DoctorCheck], name: &str) -> &'a DoctorCheck {
@@ -685,6 +1300,63 @@ mod tests {
             .iter()
             .find(|c| c.name == name)
             .expect("check present")
+    }
+
+    fn registry_names(options: DoctorOptions) -> Vec<&'static str> {
+        check_registry::<StubProbe, StubDeviceOpener, StubPolkitInspector>()
+            .into_iter()
+            .filter(|spec| spec.enabled(options))
+            .map(|spec| spec.name)
+            .collect()
+    }
+
+    fn check_names(outcome: &DoctorOutcome) -> Vec<&str> {
+        outcome
+            .checks
+            .iter()
+            .map(|check| check.name.as_str())
+            .collect()
+    }
+
+    #[test]
+    fn registry_default_profile_excludes_polkit_checks() {
+        assert_eq!(
+            registry_names(DoctorOptions {
+                include_polkit: false
+            }),
+            vec![
+                CHECK_CONFIG,
+                CHECK_VIDEO_DEVICE,
+                CHECK_EMBEDDING_DIR,
+                CHECK_LANDMARK_MODEL,
+                CHECK_ENCODER_MODEL,
+                CHECK_SECRET_SERVICE,
+                CHECK_PAM_STACK,
+                CHECK_PAM_MODULE,
+            ]
+        );
+    }
+
+    #[test]
+    fn registry_polkit_profile_appends_polkit_checks() {
+        assert_eq!(
+            registry_names(DoctorOptions {
+                include_polkit: true
+            }),
+            vec![
+                CHECK_CONFIG,
+                CHECK_VIDEO_DEVICE,
+                CHECK_EMBEDDING_DIR,
+                CHECK_LANDMARK_MODEL,
+                CHECK_ENCODER_MODEL,
+                CHECK_SECRET_SERVICE,
+                CHECK_PAM_STACK,
+                CHECK_PAM_MODULE,
+                CHECK_POLKIT_HELPER_UNIT,
+                CHECK_POLKIT_SESSION_BUS_ACCESS,
+                CHECK_POLKIT_VIDEO_DEVICE_ACCESS,
+            ]
+        );
     }
 
     #[test]
@@ -712,6 +1384,19 @@ mod tests {
         );
 
         assert!(outcome.ok, "statuses: {:?}", outcome.checks);
+        assert_eq!(
+            check_names(&outcome),
+            vec![
+                CHECK_CONFIG,
+                CHECK_VIDEO_DEVICE,
+                CHECK_EMBEDDING_DIR,
+                CHECK_LANDMARK_MODEL,
+                CHECK_ENCODER_MODEL,
+                CHECK_SECRET_SERVICE,
+                CHECK_PAM_STACK,
+                CHECK_PAM_MODULE,
+            ]
+        );
         assert_eq!(
             status(&outcome.checks, CHECK_CONFIG).status,
             CheckStatus::Pass
@@ -903,6 +1588,47 @@ mod tests {
     }
 
     #[test]
+    fn pam_module_check_uses_module_path_discovered_by_pam_stack() {
+        let tmp = tempdir().unwrap();
+        write_fixtures(tmp.path());
+        fs::write(
+            tmp.path().join("config.toml"),
+            format!(
+                "embedding_store_dir = \"{}\"\nvideo_device = \"{}\"\nlandmark_model = \"{}\"\nencoder_model = \"{}\"\n",
+                tmp.path().join("store").display(),
+                tmp.path().join("video0").display(),
+                tmp.path().join("landmark.dat").display(),
+                tmp.path().join("encoder.dat").display()
+            ),
+        )
+        .unwrap();
+        fs::remove_file(tmp.path().join("libpam_chissu.so")).unwrap();
+        let referenced_module = tmp.path().join("custom/libpam_chissu.so");
+        fs::create_dir_all(referenced_module.parent().unwrap()).unwrap();
+        File::create(&referenced_module).unwrap();
+        fs::set_permissions(&referenced_module, fs::Permissions::from_mode(0o644)).unwrap();
+        fs::write(
+            tmp.path().join("pam.d/login"),
+            format!("auth sufficient {}\n", referenced_module.display()),
+        )
+        .unwrap();
+
+        let outcome = doctor_with(
+            base_paths(tmp.path()),
+            StubProbe { result: Ok(()) },
+            true,
+            resolved_for(tmp.path()),
+        );
+
+        let check = status(&outcome.checks, CHECK_PAM_MODULE);
+        assert_eq!(check.status, CheckStatus::Pass);
+        assert_eq!(
+            check.path.as_deref(),
+            Some(referenced_module.to_str().unwrap())
+        );
+    }
+
+    #[test]
     fn doctor_accepts_sticky_non_listable_embedding_dir() {
         let tmp = tempdir().unwrap();
         write_fixtures(tmp.path());
@@ -1010,5 +1736,214 @@ mod tests {
             status(&outcome.checks, CHECK_PAM_MODULE).status,
             CheckStatus::Fail
         );
+    }
+
+    #[test]
+    fn plain_doctor_does_not_include_polkit_checks() {
+        let tmp = tempdir().unwrap();
+        write_fixtures(tmp.path());
+        fs::write(
+            tmp.path().join("config.toml"),
+            format!(
+                "embedding_store_dir = \"{}\"\nvideo_device = \"{}\"\nlandmark_model = \"{}\"\nencoder_model = \"{}\"\n",
+                tmp.path().join("store").display(),
+                tmp.path().join("video0").display(),
+                tmp.path().join("landmark.dat").display(),
+                tmp.path().join("encoder.dat").display()
+            ),
+        )
+        .unwrap();
+
+        let outcome = doctor_with(
+            base_paths(tmp.path()),
+            StubProbe { result: Ok(()) },
+            true,
+            resolved_for(tmp.path()),
+        );
+
+        assert!(outcome
+            .checks
+            .iter()
+            .all(|check| !check.name.starts_with("polkit_")));
+    }
+
+    #[test]
+    fn polkit_doctor_includes_polkit_checks() {
+        let tmp = tempdir().unwrap();
+        write_fixtures(tmp.path());
+        fs::write(
+            tmp.path().join("config.toml"),
+            format!(
+                "embedding_store_dir = \"{}\"\nvideo_device = \"/dev/video2\"\nlandmark_model = \"{}\"\nencoder_model = \"{}\"\n",
+                tmp.path().join("store").display(),
+                tmp.path().join("landmark.dat").display(),
+                tmp.path().join("encoder.dat").display()
+            ),
+        )
+        .unwrap();
+
+        let outcome = doctor_with_options(
+            base_paths(tmp.path()),
+            StubProbe { result: Ok(()) },
+            true,
+            resolved_for(tmp.path()),
+            DoctorOptions {
+                include_polkit: true,
+            },
+            Ok(recommended_polkit_settings()),
+        );
+
+        assert_eq!(
+            check_names(&outcome),
+            vec![
+                CHECK_CONFIG,
+                CHECK_VIDEO_DEVICE,
+                CHECK_EMBEDDING_DIR,
+                CHECK_LANDMARK_MODEL,
+                CHECK_ENCODER_MODEL,
+                CHECK_SECRET_SERVICE,
+                CHECK_PAM_STACK,
+                CHECK_PAM_MODULE,
+                CHECK_POLKIT_HELPER_UNIT,
+                CHECK_POLKIT_SESSION_BUS_ACCESS,
+                CHECK_POLKIT_VIDEO_DEVICE_ACCESS,
+            ]
+        );
+        assert_eq!(
+            status(&outcome.checks, CHECK_POLKIT_HELPER_UNIT).status,
+            CheckStatus::Pass
+        );
+        assert_eq!(
+            status(&outcome.checks, CHECK_POLKIT_SESSION_BUS_ACCESS).status,
+            CheckStatus::Pass
+        );
+        assert_eq!(
+            status(&outcome.checks, CHECK_POLKIT_VIDEO_DEVICE_ACCESS).status,
+            CheckStatus::Pass
+        );
+    }
+
+    #[test]
+    fn strict_polkit_unit_fails_bus_and_camera_checks() {
+        let settings = parse_systemctl_cat(
+            r#"
+[Service]
+ProtectHome=yes
+PrivateDevices=yes
+DevicePolicy=strict
+DeviceAllow=/dev/null rw
+"#,
+        );
+
+        assert_eq!(
+            check_polkit_session_bus_access(&settings).status,
+            CheckStatus::Fail
+        );
+        assert_eq!(
+            check_polkit_video_device_access(&settings, "/dev/video2").status,
+            CheckStatus::Fail
+        );
+    }
+
+    #[test]
+    fn recommended_polkit_override_passes_bus_and_camera_checks() {
+        let settings = recommended_polkit_settings();
+
+        assert_eq!(
+            check_polkit_session_bus_access(&settings).status,
+            CheckStatus::Pass
+        );
+        assert_eq!(
+            check_polkit_video_device_access(&settings, "/dev/video2").status,
+            CheckStatus::Pass
+        );
+    }
+
+    #[test]
+    fn polkit_video_check_fails_when_camera_allow_is_missing() {
+        let settings = parse_systemctl_show(
+            r#"
+LoadState=loaded
+ProtectHome=tmpfs
+BindReadOnlyPaths=/run/user
+BindPaths=/dev/video2
+PrivateDevices=yes
+DevicePolicy=strict
+DeviceAllow=/dev/null rw
+"#,
+        );
+
+        let check = check_polkit_video_device_access(&settings, "/dev/video2");
+
+        assert_eq!(check.status, CheckStatus::Fail);
+        assert!(check.message.contains("DevicePolicy=strict"));
+    }
+
+    #[test]
+    fn unavailable_polkit_unit_reports_warnings() {
+        let tmp = tempdir().unwrap();
+        write_fixtures(tmp.path());
+
+        let outcome = doctor_with_options(
+            base_paths(tmp.path()),
+            StubProbe { result: Ok(()) },
+            true,
+            resolved_for(tmp.path()),
+            DoctorOptions {
+                include_polkit: true,
+            },
+            Err("systemctl unavailable".into()),
+        );
+
+        assert_eq!(
+            status(&outcome.checks, CHECK_POLKIT_HELPER_UNIT).status,
+            CheckStatus::Warn
+        );
+        assert_eq!(
+            status(&outcome.checks, CHECK_POLKIT_SESSION_BUS_ACCESS).status,
+            CheckStatus::Warn
+        );
+        assert_eq!(
+            status(&outcome.checks, CHECK_POLKIT_VIDEO_DEVICE_ACCESS).status,
+            CheckStatus::Warn
+        );
+    }
+
+    #[test]
+    fn missing_polkit_unit_skips_dependent_checks() {
+        let settings = parse_systemctl_show("LoadState=not-found\n");
+
+        assert_eq!(
+            check_polkit_helper_unit(&settings).status,
+            CheckStatus::Warn
+        );
+        assert_eq!(
+            check_polkit_session_bus_access(&settings).status,
+            CheckStatus::Warn
+        );
+        assert_eq!(
+            check_polkit_video_device_access(&settings, "/dev/video2").status,
+            CheckStatus::Warn
+        );
+    }
+
+    fn recommended_polkit_settings() -> PolkitUnitSettings {
+        parse_systemctl_cat(
+            r#"
+# /usr/lib/systemd/system/polkit-agent-helper@.service
+[Service]
+ProtectHome=yes
+PrivateDevices=yes
+DevicePolicy=strict
+DeviceAllow=/dev/null rw
+
+# /etc/systemd/system/polkit-agent-helper@.service.d/override.conf
+[Service]
+ProtectHome=tmpfs
+BindReadOnlyPaths=/run/user
+BindPaths=/dev/video2
+DeviceAllow=/dev/video2 rw
+"#,
+        )
     }
 }

--- a/crates/chissu-cli/src/doctor.rs
+++ b/crates/chissu-cli/src/doctor.rs
@@ -647,6 +647,7 @@ mod tests {
             capture_timeout_secs: None,
             frame_interval_millis: None,
             require_secret_service: None,
+            secret_service_session: None,
         };
         ResolvedConfig::from_raw(raw)
     }

--- a/crates/chissu-cli/tests/command_dispatch.rs
+++ b/crates/chissu-cli/tests/command_dispatch.rs
@@ -2,8 +2,8 @@ use std::path::PathBuf;
 
 use chissu_cli::capture::CaptureHandler;
 use chissu_cli::cli::{
-    CaptureArgs, Commands, EnrollArgs, FaceExtractArgs, FacesCommands, KeyringCheckArgs,
-    KeyringCommands,
+    CaptureArgs, Commands, DoctorArgs, EnrollArgs, FaceExtractArgs, FacesCommands,
+    KeyringCheckArgs, KeyringCommands,
 };
 use chissu_cli::commands::{
     CommandHandler, DoctorHandler, EnrollHandler, FacesHandler, KeyringHandler,
@@ -79,5 +79,5 @@ fn keyring_command_dispatches_keyring_handler() {
 
 #[test]
 fn doctor_command_dispatches_doctor_handler() {
-    assert_dispatch::<DoctorHandler>(Commands::Doctor);
+    assert_dispatch::<DoctorHandler>(Commands::Doctor(DoctorArgs { polkit: false }));
 }

--- a/crates/chissu-cli/tests/doctor_handler.rs
+++ b/crates/chissu-cli/tests/doctor_handler.rs
@@ -1,7 +1,7 @@
 use std::process::ExitCode;
 use std::sync::{Arc, Mutex};
 
-use chissu_cli::cli::OutputMode;
+use chissu_cli::cli::{DoctorArgs, OutputMode};
 use chissu_cli::commands::{CommandHandler, DoctorHandler};
 use chissu_cli::doctor::{CheckStatus, DoctorCheck, DoctorOutcome};
 use chissu_cli::errors::AppError;
@@ -26,23 +26,36 @@ fn sample_outcome(ok: bool) -> DoctorOutcome {
 #[test]
 fn doctor_handler_uses_render_and_exit_code() {
     let renders = Arc::new(Mutex::new(0));
-    let handler = DoctorHandler::with_dependencies(|| Ok(sample_outcome(false)), {
-        let renders = Arc::clone(&renders);
-        move |_outcome, _mode| {
-            *renders.lock().unwrap() += 1;
-            Ok(())
-        }
-    });
+    let captured = Arc::new(Mutex::new(None));
+    let handler = DoctorHandler::with_dependencies(
+        DoctorArgs { polkit: true },
+        {
+            let captured = Arc::clone(&captured);
+            move |options| {
+                *captured.lock().unwrap() = Some(options);
+                Ok(sample_outcome(false))
+            }
+        },
+        {
+            let renders = Arc::clone(&renders);
+            move |_outcome, _mode| {
+                *renders.lock().unwrap() += 1;
+                Ok(())
+            }
+        },
+    );
 
     let code = handler.execute(OutputMode::Human, false).unwrap();
     assert_eq!(code, ExitCode::from(1));
     assert_eq!(*renders.lock().unwrap(), 1);
+    assert!(captured.lock().unwrap().unwrap().include_polkit);
 }
 
 #[test]
 fn doctor_handler_propagates_errors() {
     let handler = DoctorHandler::with_dependencies(
-        || Err(AppError::Capability("boom".into())),
+        DoctorArgs { polkit: false },
+        |_options| Err(AppError::Capability("boom".into())),
         |_outcome, _mode| Ok(()),
     );
 

--- a/crates/chissu-config/src/lib.rs
+++ b/crates/chissu-config/src/lib.rs
@@ -17,6 +17,21 @@ pub const DEFAULT_PIXEL_FORMAT: &str = "Y16";
 pub const DEFAULT_WARMUP_FRAMES: u32 = 4;
 pub const DEFAULT_JITTERS: u32 = 1;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SecretServiceSessionMode {
+    Auto,
+    #[serde(rename = "x11")]
+    X11,
+    Wayland,
+}
+
+impl Default for SecretServiceSessionMode {
+    fn default() -> Self {
+        Self::Auto
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct ConfigFile {
     pub similarity_threshold: Option<f64>,
@@ -30,6 +45,7 @@ pub struct ConfigFile {
     pub landmark_model: Option<PathBuf>,
     pub encoder_model: Option<PathBuf>,
     pub require_secret_service: Option<bool>,
+    pub secret_service_session: Option<SecretServiceSessionMode>,
 }
 
 #[derive(Debug, Clone)]
@@ -45,6 +61,7 @@ pub struct ResolvedConfig {
     pub landmark_model: Option<PathBuf>,
     pub encoder_model: Option<PathBuf>,
     pub require_secret_service: bool,
+    pub secret_service_session: SecretServiceSessionMode,
 }
 
 impl ResolvedConfig {
@@ -75,6 +92,7 @@ impl ResolvedConfig {
             landmark_model: raw.landmark_model,
             encoder_model: raw.encoder_model,
             require_secret_service: raw.require_secret_service.unwrap_or(true),
+            secret_service_session: raw.secret_service_session.unwrap_or_default(),
         }
     }
 }
@@ -261,6 +279,10 @@ mod tests {
         );
         assert_eq!(resolved.resolved.video_device, DEFAULT_VIDEO_DEVICE);
         assert_eq!(resolved.resolved.warmup_frames, DEFAULT_WARMUP_FRAMES);
+        assert_eq!(
+            resolved.resolved.secret_service_session,
+            SecretServiceSessionMode::Auto
+        );
     }
 
     #[test]
@@ -272,5 +294,34 @@ mod tests {
         let resolved = load_resolved_from_paths(&[primary.clone()]).unwrap();
         assert_eq!(resolved.source, Some(primary));
         assert_eq!(resolved.resolved.capture_timeout, Duration::from_secs(10));
+    }
+
+    #[test]
+    fn parses_secret_service_session_modes() {
+        let dir = tempdir().unwrap();
+        for (raw, expected) in [
+            ("auto", SecretServiceSessionMode::Auto),
+            ("x11", SecretServiceSessionMode::X11),
+            ("wayland", SecretServiceSessionMode::Wayland),
+        ] {
+            let path = dir.path().join(format!("{raw}.toml"));
+            fs::write(&path, format!("secret_service_session = \"{raw}\"")).unwrap();
+
+            let loaded = load_resolved_from_paths(&[path]).unwrap();
+            assert_eq!(loaded.resolved.secret_service_session, expected);
+        }
+    }
+
+    #[test]
+    fn rejects_unknown_secret_service_session_mode() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("broken.toml");
+        fs::write(&path, "secret_service_session = \"mir\"").unwrap();
+
+        let err = load_from_paths(&[path.clone()]).unwrap_err();
+        match err {
+            ConfigError::Parse { path: err_path, .. } => assert_eq!(err_path, path),
+            other => panic!("unexpected error: {:?}", other),
+        }
     }
 }

--- a/crates/chissu-config/src/lib.rs
+++ b/crates/chissu-config/src/lib.rs
@@ -17,19 +17,14 @@ pub const DEFAULT_PIXEL_FORMAT: &str = "Y16";
 pub const DEFAULT_WARMUP_FRAMES: u32 = 4;
 pub const DEFAULT_JITTERS: u32 = 1;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum SecretServiceSessionMode {
+    #[default]
     Auto,
     #[serde(rename = "x11")]
     X11,
     Wayland,
-}
-
-impl Default for SecretServiceSessionMode {
-    fn default() -> Self {
-        Self::Auto
-    }
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]

--- a/crates/chissu-face-core/src/capture/device.rs
+++ b/crates/chissu-face-core/src/capture/device.rs
@@ -95,7 +95,7 @@ struct V4lStream<'a> {
     stream: Stream<'a>,
 }
 
-impl<'a> CaptureStream for V4lStream<'a> {
+impl CaptureStream for V4lStream<'_> {
     fn next(&mut self) -> AppResult<Vec<u8>> {
         let (data, _) = self.stream.next().map_err(AppError::from)?;
         Ok(data.to_vec())

--- a/crates/pam-chissu/src/lib.rs
+++ b/crates/pam-chissu/src/lib.rs
@@ -10,7 +10,9 @@ use std::slice;
 use std::thread::sleep;
 use std::time::{Duration, Instant};
 
-use chissu_config::{self, ConfigError, ResolvedConfig, ResolvedConfigWithSource};
+use chissu_config::{
+    self, ConfigError, ResolvedConfig, ResolvedConfigWithSource, SecretServiceSessionMode,
+};
 use chissu_face_core::capture::{capture_frame_in_memory, CaptureConfig, DeviceLocator};
 use chissu_face_core::errors::AppError;
 use chissu_face_core::faces::{
@@ -21,7 +23,7 @@ use chissu_face_core::faces::{
 use chissu_face_core::secret_service::default_service_name;
 use image::{Rgb, RgbImage};
 use libc::{c_int, free};
-use logind::LogindInspector;
+use logind::{EffectiveSessionMode, LogindInspector};
 use nix::unistd::{getegid, geteuid, User};
 use pam_sys::{
     get_item, get_user, ConvClosure, PamConversation, PamHandle, PamItemType, PamMessage,
@@ -375,7 +377,7 @@ fn authenticate_user(
     let mut helper_env: Option<HelperEnvOverrides> = None;
 
     if config.require_secret_service {
-        helper_env = prepare_helper_env(request, logger);
+        helper_env = prepare_helper_env(request, config.secret_service_session, logger);
         log_privilege_drop_context(&request.user, logger);
         match run_secret_service_helper(&request.user, config.capture_timeout, helper_env.as_ref())
         {
@@ -681,13 +683,11 @@ fn load_config() -> PamResult<ResolvedConfigWithSource> {
     chissu_config::load_resolved_config().map_err(map_config_error)
 }
 
-fn prepare_helper_env(request: &PamRequest, logger: &mut PamLogger) -> Option<HelperEnvOverrides> {
-    let needs = HelperEnvNeeds::detect();
-    if !needs.any() {
-        logger.debug("DISPLAY/DBUS/XDG already present; skipping logind environment hydration");
-        return None;
-    }
-
+fn prepare_helper_env(
+    request: &PamRequest,
+    session_mode: SecretServiceSessionMode,
+    logger: &mut PamLogger,
+) -> Option<HelperEnvOverrides> {
     let uid = match lookup_uid(&request.user) {
         Ok(uid) => uid,
         Err(err) => {
@@ -702,23 +702,39 @@ fn prepare_helper_env(request: &PamRequest, logger: &mut PamLogger) -> Option<He
     let inspector = LogindInspector::new();
     match inspector.inspect(uid, request.tty.as_deref()) {
         Ok(Some(env)) => {
+            let effective_mode = env.effective_session_mode(session_mode);
             let pairs: Vec<(String, String)> = env
-                .env_pairs()
+                .env_pairs(session_mode)
                 .into_iter()
-                .filter(|(key, _)| needs.accepts(key))
+                .filter(|(key, value)| should_apply_env_override(key, value))
                 .collect();
-            if pairs.is_empty() {
+            let removals = opposite_session_env_removals(effective_mode);
+            if pairs.is_empty() && removals.is_empty() {
                 logger.debug(
-                    "Logind session found but no missing environment variables required overrides",
+                    "Logind session found but no Secret Service environment overrides were needed",
                 );
                 None
             } else {
+                let applied = pairs
+                    .iter()
+                    .map(|(key, _)| key.as_str())
+                    .collect::<Vec<_>>()
+                    .join(",");
+                let removed = removals
+                    .iter()
+                    .map(String::as_str)
+                    .collect::<Vec<_>>()
+                    .join(",");
                 logger.info(&format!(
-                    "Recovered session environment from logind for user '{}': {}",
+                    "Recovered Secret Service session environment from logind for user '{}': {} configured_mode={} selected_mode={} applied={} removed={}",
                     request.user,
-                    env.summary()
+                    env.summary(),
+                    session_mode_name(session_mode),
+                    effective_mode.as_str(),
+                    applied,
+                    removed,
                 ));
-                Some(HelperEnvOverrides::from_pairs(pairs))
+                Some(HelperEnvOverrides::from_parts(pairs, removals))
             }
         }
         Ok(None) => {
@@ -757,40 +773,54 @@ fn map_config_error(err: ConfigError) -> AuthError {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-struct HelperEnvNeeds {
-    display: bool,
-    runtime: bool,
-    dbus: bool,
-}
-
-impl HelperEnvNeeds {
-    fn detect() -> Self {
-        Self {
-            display: env_var_missing("DISPLAY"),
-            runtime: env_var_missing("XDG_RUNTIME_DIR"),
-            dbus: env_var_missing("DBUS_SESSION_BUS_ADDRESS"),
-        }
-    }
-
-    fn any(&self) -> bool {
-        self.display || self.runtime || self.dbus
-    }
-
-    fn accepts(&self, key: &str) -> bool {
-        match key {
-            "DISPLAY" | "WAYLAND_DISPLAY" => self.display,
-            "XDG_RUNTIME_DIR" => self.runtime,
-            "DBUS_SESSION_BUS_ADDRESS" => self.dbus,
-            _ => false,
-        }
-    }
-}
-
 fn env_var_missing(name: &str) -> bool {
     match env::var_os(name) {
         Some(value) => value.is_empty(),
         None => true,
+    }
+}
+
+fn should_apply_env_override(key: &str, value: &str) -> bool {
+    match key {
+        "DISPLAY" | "WAYLAND_DISPLAY" => env_var_missing(key),
+        "XDG_RUNTIME_DIR" => env::var(key).map_or(true, |current| current != value),
+        "DBUS_SESSION_BUS_ADDRESS" => dbus_env_needs_override(value),
+        _ => false,
+    }
+}
+
+fn opposite_session_env_removals(mode: EffectiveSessionMode) -> Vec<String> {
+    match mode {
+        EffectiveSessionMode::X11 if env_var_present("WAYLAND_DISPLAY") => {
+            vec!["WAYLAND_DISPLAY".into()]
+        }
+        EffectiveSessionMode::Wayland if env_var_present("DISPLAY") => vec!["DISPLAY".into()],
+        _ => Vec::new(),
+    }
+}
+
+fn dbus_env_needs_override(target_address: &str) -> bool {
+    match env::var("DBUS_SESSION_BUS_ADDRESS") {
+        Ok(current) => {
+            let trimmed = current.trim();
+            trimmed.is_empty() || trimmed.starts_with("autolaunch:") || trimmed != target_address
+        }
+        Err(_) => true,
+    }
+}
+
+fn env_var_present(name: &str) -> bool {
+    match env::var_os(name) {
+        Some(value) => !value.is_empty(),
+        None => false,
+    }
+}
+
+fn session_mode_name(mode: SecretServiceSessionMode) -> &'static str {
+    match mode {
+        SecretServiceSessionMode::Auto => "auto",
+        SecretServiceSessionMode::X11 => "x11",
+        SecretServiceSessionMode::Wayland => "wayland",
     }
 }
 
@@ -1076,6 +1106,59 @@ mod tests {
             "helper produced no response".into(),
         ));
         assert!(matches!(err, AuthError::Pam(message) if message.contains("no response")));
+    }
+
+    #[test]
+    #[serial]
+    fn dbus_env_override_accepts_missing_empty_and_autolaunch_values() {
+        env::remove_var("DBUS_SESSION_BUS_ADDRESS");
+        assert!(dbus_env_needs_override("unix:path=/run/user/1000/bus"));
+
+        env::set_var("DBUS_SESSION_BUS_ADDRESS", "");
+        assert!(dbus_env_needs_override("unix:path=/run/user/1000/bus"));
+
+        env::set_var("DBUS_SESSION_BUS_ADDRESS", "autolaunch:scope=abc");
+        assert!(dbus_env_needs_override("unix:path=/run/user/1000/bus"));
+    }
+
+    #[test]
+    #[serial]
+    fn dbus_env_override_rejects_wrong_runtime_bus() {
+        env::set_var("DBUS_SESSION_BUS_ADDRESS", "unix:path=/run/user/2000/bus");
+
+        assert!(dbus_env_needs_override("unix:path=/run/user/1000/bus"));
+    }
+
+    #[test]
+    #[serial]
+    fn dbus_env_override_keeps_target_runtime_bus() {
+        env::set_var("DBUS_SESSION_BUS_ADDRESS", "unix:path=/run/user/1000/bus");
+
+        assert!(!dbus_env_needs_override("unix:path=/run/user/1000/bus"));
+    }
+
+    #[test]
+    #[serial]
+    fn opposite_session_env_removals_clear_display_for_wayland() {
+        env::set_var("DISPLAY", ":0");
+        env::remove_var("WAYLAND_DISPLAY");
+
+        assert_eq!(
+            opposite_session_env_removals(EffectiveSessionMode::Wayland),
+            vec!["DISPLAY".to_string()]
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn opposite_session_env_removals_clear_wayland_for_x11() {
+        env::remove_var("DISPLAY");
+        env::set_var("WAYLAND_DISPLAY", "wayland-0");
+
+        assert_eq!(
+            opposite_session_env_removals(EffectiveSessionMode::X11),
+            vec!["WAYLAND_DISPLAY".to_string()]
+        );
     }
 
     #[test]

--- a/crates/pam-chissu/src/logind.rs
+++ b/crates/pam-chissu/src/logind.rs
@@ -1,3 +1,7 @@
+use std::os::unix::fs::FileTypeExt;
+use std::path::PathBuf;
+
+use chissu_config::SecretServiceSessionMode;
 use thiserror::Error;
 use zbus::{
     blocking::{Connection, Proxy},
@@ -32,7 +36,10 @@ impl LogindInspector {
             "org.freedesktop.login1.User",
         )?;
 
-        let runtime_dir = normalize_string(user_proxy.get_property::<String>("RuntimePath").ok());
+        let runtime_dir = resolve_runtime_dir(
+            uid,
+            normalize_string(user_proxy.get_property::<String>("RuntimePath").ok()),
+        );
         let sessions: Vec<(String, OwnedObjectPath)> = user_proxy.get_property("Sessions")?;
         if sessions.is_empty() {
             return Ok(None);
@@ -141,12 +148,16 @@ impl SessionEnvironment {
         }
     }
 
-    pub fn env_pairs(&self) -> Vec<(String, String)> {
+    pub fn env_pairs(&self, configured_mode: SecretServiceSessionMode) -> Vec<(String, String)> {
         let mut pairs = Vec::new();
         if let Some(display) = &self.display {
-            pairs.push(("DISPLAY".into(), display.clone()));
-            if self.session_type.as_deref() == Some("wayland") {
-                pairs.push(("WAYLAND_DISPLAY".into(), display.clone()));
+            match self.effective_session_mode(configured_mode) {
+                EffectiveSessionMode::X11 | EffectiveSessionMode::Unknown => {
+                    pairs.push(("DISPLAY".into(), display.clone()));
+                }
+                EffectiveSessionMode::Wayland => {
+                    pairs.push(("WAYLAND_DISPLAY".into(), display.clone()));
+                }
             }
         }
         if let Some(runtime) = &self.runtime_dir {
@@ -156,6 +167,17 @@ impl SessionEnvironment {
             pairs.push(("DBUS_SESSION_BUS_ADDRESS".into(), address.clone()));
         }
         pairs
+    }
+
+    pub fn effective_session_mode(
+        &self,
+        configured_mode: SecretServiceSessionMode,
+    ) -> EffectiveSessionMode {
+        effective_session_mode(
+            configured_mode,
+            self.session_type.as_deref(),
+            self.display.as_deref(),
+        )
     }
 
     pub fn summary(&self) -> String {
@@ -168,6 +190,23 @@ impl SessionEnvironment {
             self.display.as_deref().unwrap_or("-"),
             self.runtime_dir.as_deref().unwrap_or("-"),
         )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EffectiveSessionMode {
+    X11,
+    Wayland,
+    Unknown,
+}
+
+impl EffectiveSessionMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::X11 => "x11",
+            Self::Wayland => "wayland",
+            Self::Unknown => "unknown",
+        }
     }
 }
 
@@ -216,9 +255,56 @@ fn normalize_string(value: Option<String>) -> Option<String> {
     })
 }
 
+fn resolve_runtime_dir(uid: u32, logind_runtime: Option<String>) -> Option<String> {
+    logind_runtime.or_else(|| {
+        let path = PathBuf::from(format!("/run/user/{uid}/bus"));
+        runtime_dir_from_bus_path(path)
+    })
+}
+
+fn runtime_dir_from_bus_path(path: PathBuf) -> Option<String> {
+    path.metadata()
+        .ok()
+        .filter(|metadata| metadata.file_type().is_socket())
+        .and_then(|_| path.parent().map(|parent| parent.display().to_string()))
+}
+
+fn effective_session_mode(
+    configured_mode: SecretServiceSessionMode,
+    session_type: Option<&str>,
+    display: Option<&str>,
+) -> EffectiveSessionMode {
+    match configured_mode {
+        SecretServiceSessionMode::X11 => EffectiveSessionMode::X11,
+        SecretServiceSessionMode::Wayland => EffectiveSessionMode::Wayland,
+        SecretServiceSessionMode::Auto => infer_session_mode(session_type, display),
+    }
+}
+
+fn infer_session_mode(session_type: Option<&str>, display: Option<&str>) -> EffectiveSessionMode {
+    match session_type
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        Some(value) if value.eq_ignore_ascii_case("x11") => return EffectiveSessionMode::X11,
+        Some(value) if value.eq_ignore_ascii_case("wayland") => {
+            return EffectiveSessionMode::Wayland
+        }
+        _ => {}
+    }
+
+    match display.map(str::trim).filter(|value| !value.is_empty()) {
+        Some(value) if value.starts_with("wayland-") => EffectiveSessionMode::Wayland,
+        Some(value) if value.starts_with(':') => EffectiveSessionMode::X11,
+        _ => EffectiveSessionMode::Unknown,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::unix::net::UnixListener;
+    use tempfile::tempdir;
 
     fn record(id: &str, active: bool, class: &str, tty: Option<&str>) -> SessionRecord {
         SessionRecord {
@@ -263,9 +349,9 @@ mod tests {
             session_type: Some("wayland".into()),
         };
         let env = SessionEnvironment::from_record(record, Some("/run/user/1000".into()));
-        let mut pairs = env.env_pairs();
+        let mut pairs = env.env_pairs(SecretServiceSessionMode::Auto);
         pairs.sort_by(|a, b| a.0.cmp(&b.0));
-        assert_eq!(pairs.len(), 4);
+        assert_eq!(pairs.len(), 3);
         assert_eq!(
             pairs[0],
             (
@@ -273,11 +359,80 @@ mod tests {
                 "unix:path=/run/user/1000/bus".into()
             )
         );
-        assert_eq!(pairs[1], ("DISPLAY".into(), "wayland-0".into()));
-        assert_eq!(pairs[2], ("WAYLAND_DISPLAY".into(), "wayland-0".into()));
+        assert_eq!(pairs[1], ("WAYLAND_DISPLAY".into(), "wayland-0".into()));
         assert_eq!(
-            pairs[3],
+            pairs[2],
             ("XDG_RUNTIME_DIR".into(), "/run/user/1000".into())
+        );
+    }
+
+    #[test]
+    fn env_pairs_include_display_for_x11() {
+        let record = SessionRecord {
+            id: "6".into(),
+            seat: None,
+            tty: Some("tty2".into()),
+            state: "active".into(),
+            class: "user".into(),
+            active: true,
+            display: Some(":0".into()),
+            session_type: Some("x11".into()),
+        };
+        let env = SessionEnvironment::from_record(record, Some("/run/user/1000".into()));
+        let pairs = env.env_pairs(SecretServiceSessionMode::Auto);
+
+        assert!(pairs.contains(&("DISPLAY".into(), ":0".into())));
+        assert!(!pairs.iter().any(|(key, _)| key == "WAYLAND_DISPLAY"));
+        assert!(pairs.contains(&(
+            "DBUS_SESSION_BUS_ADDRESS".into(),
+            "unix:path=/run/user/1000/bus".into()
+        )));
+    }
+
+    #[test]
+    fn configured_mode_overrides_logind_type() {
+        let record = SessionRecord {
+            id: "7".into(),
+            seat: None,
+            tty: Some("tty2".into()),
+            state: "active".into(),
+            class: "user".into(),
+            active: true,
+            display: Some(":0".into()),
+            session_type: Some("x11".into()),
+        };
+        let env = SessionEnvironment::from_record(record, Some("/run/user/1000".into()));
+        let pairs = env.env_pairs(SecretServiceSessionMode::Wayland);
+
+        assert!(pairs.contains(&("WAYLAND_DISPLAY".into(), ":0".into())));
+        assert!(!pairs.iter().any(|(key, _)| key == "DISPLAY"));
+    }
+
+    #[test]
+    fn auto_infers_wayland_from_display_when_type_is_missing() {
+        assert_eq!(
+            effective_session_mode(SecretServiceSessionMode::Auto, None, Some("wayland-0")),
+            EffectiveSessionMode::Wayland
+        );
+    }
+
+    #[test]
+    fn auto_infers_x11_from_display_when_type_is_missing() {
+        assert_eq!(
+            effective_session_mode(SecretServiceSessionMode::Auto, None, Some(":1")),
+            EffectiveSessionMode::X11
+        );
+    }
+
+    #[test]
+    fn runtime_dir_falls_back_from_existing_bus_socket() {
+        let dir = tempdir().unwrap();
+        let bus = dir.path().join("bus");
+        let _listener = UnixListener::bind(&bus).unwrap();
+
+        assert_eq!(
+            runtime_dir_from_bus_path(bus),
+            Some(dir.path().display().to_string())
         );
     }
 }

--- a/crates/pam-chissu/src/secret_helper.rs
+++ b/crates/pam-chissu/src/secret_helper.rs
@@ -1,8 +1,11 @@
 use std::env;
 use std::ffi::{CString, OsString};
+use std::fs;
 use std::io::{self, Read, Write};
 use std::net::Shutdown;
+use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
 use std::os::unix::net::UnixStream;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use base64::{engine::general_purpose, Engine as _};
@@ -12,7 +15,8 @@ use chissu_face_core::secret_service::{
 use nix::sys::signal::{kill, Signal};
 use nix::sys::wait::{waitpid, WaitStatus};
 use nix::unistd::{
-    fork, getegid, geteuid, initgroups, setgid, setuid, ForkResult, Gid, Pid, Uid, User,
+    fork, getegid, geteuid, getgid, getuid, initgroups, setgid, setuid, ForkResult, Gid, Pid, Uid,
+    User,
 };
 use serde::{Deserialize, Serialize};
 
@@ -79,19 +83,25 @@ enum PrivilegeDropPlan {
 #[derive(Debug, Clone, Default)]
 pub struct HelperEnvOverrides {
     vars: Vec<(OsString, OsString)>,
+    removals: Vec<OsString>,
 }
 
 impl HelperEnvOverrides {
-    pub fn from_pairs(pairs: Vec<(String, String)>) -> Self {
+    pub fn from_parts(pairs: Vec<(String, String)>, removals: Vec<String>) -> Self {
         let vars = pairs
             .into_iter()
             .map(|(k, v)| (OsString::from(k), OsString::from(v)))
             .collect();
-        Self { vars }
+        let removals = removals.into_iter().map(OsString::from).collect();
+        Self { vars, removals }
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &(OsString, OsString)> {
         self.vars.iter()
+    }
+
+    pub fn removals(&self) -> impl Iterator<Item = &OsString> {
+        self.removals.iter()
     }
 }
 
@@ -149,6 +159,18 @@ fn child_entry(
         );
     }
 
+    if let Err(message) = preflight_session_bus() {
+        emit_and_exit(
+            &mut stream,
+            HelperWireMessage::Error {
+                kind: HelperWireErrorKind::SecretServiceUnavailable,
+                message,
+                stage: None,
+                errno: None,
+            },
+        );
+    }
+
     let username = user.name.clone();
     match fetch_embedding_key(&username) {
         Ok(EmbeddingKeyStatus::Present(key)) => {
@@ -169,11 +191,12 @@ fn child_entry(
             );
         }
         Err(EmbeddingKeyLookupError::SecretService(err)) => {
+            let message = format!("{err}; {}", helper_context_summary());
             emit_and_exit(
                 &mut stream,
                 HelperWireMessage::Error {
                     kind: HelperWireErrorKind::SecretServiceUnavailable,
-                    message: err.to_string(),
+                    message,
                     stage: None,
                     errno: None,
                 },
@@ -247,8 +270,80 @@ fn emit_and_exit(stream: &mut UnixStream, payload: HelperWireMessage) -> ! {
 }
 
 fn apply_env_overrides(overrides: &HelperEnvOverrides) {
+    for key in overrides.removals() {
+        env::remove_var(key);
+    }
     for (key, value) in overrides.iter() {
         env::set_var(key, value);
+    }
+}
+
+fn preflight_session_bus() -> Result<(), String> {
+    let Some(address) = env::var_os("DBUS_SESSION_BUS_ADDRESS") else {
+        return Ok(());
+    };
+    let Some(path) = session_bus_path(address.to_string_lossy().as_ref()) else {
+        return Ok(());
+    };
+
+    UnixStream::connect(&path).map(|_| ()).map_err(|err| {
+        format!(
+            "DBus session bus preflight failed for {}: {}; {}",
+            path.display(),
+            err,
+            helper_context_summary()
+        )
+    })
+}
+
+fn session_bus_path(address: &str) -> Option<PathBuf> {
+    let path = address.strip_prefix("unix:path=")?;
+    let path = path.split(',').next().unwrap_or(path).trim();
+    (!path.is_empty()).then(|| PathBuf::from(path))
+}
+
+fn helper_context_summary() -> String {
+    let bus = env::var("DBUS_SESSION_BUS_ADDRESS")
+        .ok()
+        .and_then(|address| session_bus_path(&address))
+        .map(|path| format!("bus={}", path_summary(&path)))
+        .unwrap_or_else(|| "bus=-".into());
+    let runtime = env::var("XDG_RUNTIME_DIR")
+        .ok()
+        .map(|path| format!("runtime={}", path_summary(Path::new(&path))))
+        .unwrap_or_else(|| "runtime=-".into());
+
+    format!(
+        "helper uid={} euid={} gid={} egid={} {runtime} {bus}",
+        getuid().as_raw(),
+        geteuid().as_raw(),
+        getgid().as_raw(),
+        getegid().as_raw(),
+    )
+}
+
+fn path_summary(path: &Path) -> String {
+    match fs::metadata(path) {
+        Ok(metadata) => {
+            let kind = if metadata.file_type().is_socket() {
+                "socket"
+            } else if metadata.is_dir() {
+                "dir"
+            } else if metadata.is_file() {
+                "file"
+            } else {
+                "other"
+            };
+            format!(
+                "{} kind={} uid={} gid={} mode={:o}",
+                path.display(),
+                kind,
+                metadata.uid(),
+                metadata.gid(),
+                metadata.permissions().mode() & 0o7777
+            )
+        }
+        Err(err) => format!("{} metadata_error={}", path.display(), err),
     }
 }
 
@@ -467,13 +562,17 @@ mod tests {
     fn helper_env_overrides_apply_variables() {
         env::remove_var("DISPLAY");
         env::remove_var("DBUS_SESSION_BUS_ADDRESS");
-        let overrides = HelperEnvOverrides::from_pairs(vec![
-            ("DISPLAY".into(), ":99".into()),
-            (
-                "DBUS_SESSION_BUS_ADDRESS".into(),
-                "unix:path=/tmp/fake-bus".into(),
-            ),
-        ]);
+        env::set_var("WAYLAND_DISPLAY", "wayland-0");
+        let overrides = HelperEnvOverrides::from_parts(
+            vec![
+                ("DISPLAY".into(), ":99".into()),
+                (
+                    "DBUS_SESSION_BUS_ADDRESS".into(),
+                    "unix:path=/tmp/fake-bus".into(),
+                ),
+            ],
+            Vec::new(),
+        );
         assert!(overrides.iter().next().is_some());
         apply_env_overrides(&overrides);
         assert_eq!(env::var("DISPLAY").as_deref(), Ok(":99"));
@@ -481,5 +580,38 @@ mod tests {
             env::var("DBUS_SESSION_BUS_ADDRESS").as_deref(),
             Ok("unix:path=/tmp/fake-bus")
         );
+        assert_eq!(env::var("WAYLAND_DISPLAY").as_deref(), Ok("wayland-0"));
+    }
+
+    #[test]
+    fn helper_env_overrides_remove_variables() {
+        env::set_var("DISPLAY", ":0");
+        let overrides = HelperEnvOverrides::from_parts(Vec::new(), vec!["DISPLAY".into()]);
+
+        apply_env_overrides(&overrides);
+
+        assert!(env::var("DISPLAY").is_err());
+    }
+
+    #[test]
+    fn session_bus_path_extracts_unix_path_address() {
+        assert_eq!(
+            session_bus_path("unix:path=/run/user/1000/bus,guid=abc"),
+            Some(PathBuf::from("/run/user/1000/bus"))
+        );
+        assert_eq!(session_bus_path("autolaunch:scope=abc"), None);
+    }
+
+    #[test]
+    fn preflight_session_bus_accepts_connectable_socket() {
+        let dir = tempfile::tempdir().unwrap();
+        let bus = dir.path().join("bus");
+        let _listener = std::os::unix::net::UnixListener::bind(&bus).unwrap();
+        env::set_var(
+            "DBUS_SESSION_BUS_ADDRESS",
+            format!("unix:path={}", bus.display()),
+        );
+
+        assert!(preflight_session_bus().is_ok());
     }
 }

--- a/docs/pam-auth.md
+++ b/docs/pam-auth.md
@@ -49,6 +49,7 @@ pixel_format = "Y16"            # V4L2 fourcc, default "Y16"
 warmup_frames = 2               # Discarded per-sample warm-up frames, default 0
 jitters = 2                     # Dlib jitter passes, default 1
 require_secret_service = false  # Opt-in to enforcing keyring availability before capture
+secret_service_session = "auto" # "auto", "x11", or "wayland" for helper env recovery
 landmark_model = "/opt/dlib/shape_predictor_68_face_landmarks.dat"
 encoder_model = "/opt/dlib/dlib_face_recognition_resnet_model_v1.dat"
 ```
@@ -76,7 +77,8 @@ Run `chissu-cli keyring check` (add `--json` for machine parsing) to confirm the
 Troubleshooting tips:
 
 - Ensure a session bus and `gnome-keyring-daemon` (or compatible Secret Service implementation) are running for the target user before PAM attempts begin.
-- When testing via `pamtester` or SSH, forward the DBus session variables (e.g., `DBUS_SESSION_BUS_ADDRESS`) or rely on a display manager that exports them automatically.
+- When testing via `pamtester` or SSH, forward the DBus session variables (e.g., `DBUS_SESSION_BUS_ADDRESS`) or rely on a display manager that exports them automatically. For polkit/1Password-style prompts, keep `secret_service_session = "auto"` unless logind reports the wrong session type; use `"x11"` or `"wayland"` only as an explicit override.
+- For polkit/1Password failures involving `DBus session bus preflight failed ... Permission denied` or hidden `/dev/videoX` devices, see [Polkit Agent Helper Troubleshooting](users-guide/polkit-agent-helper-troubleshooting.md).
 - Review `journalctl -t pam_chissu` for messages such as `Secret Service helper returned embedding key (...)` or `Embedding key missing for user ...` to confirm the helper outcome. Errors prefixed with `Secret Service unavailable` indicate the guard short-circuited with `PAM_IGNORE`.
 
 ## Runtime behaviour

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - `pam-chissu` now recovers Secret Service helper environment for both X11 and Wayland sessions. The new `secret_service_session = "auto"` config default detects the session type from logind, with `"x11"` and `"wayland"` available as explicit overrides for unusual desktop stacks.
+- Added optional `chissu-cli doctor --polkit` diagnostics for `polkit-agent-helper@.service` sandbox settings that can block Secret Service bus or camera access.
 - Added a user guide for troubleshooting `polkit-agent-helper@.service` sandbox issues when 1Password or other polkit prompts cannot reach the user's Secret Service bus or configured camera device.
 
 ## 2025-11-09

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,4 +1,8 @@
 # Release Notes
 
+## Unreleased
+- `pam-chissu` now recovers Secret Service helper environment for both X11 and Wayland sessions. The new `secret_service_session = "auto"` config default detects the session type from logind, with `"x11"` and `"wayland"` available as explicit overrides for unusual desktop stacks.
+- Added a user guide for troubleshooting `polkit-agent-helper@.service` sandbox issues when 1Password or other polkit prompts cannot reach the user's Secret Service bus or configured camera device.
+
 ## 2025-11-09
 - `chissu-cli capture` now reads `video_device`, `pixel_format`, and `warmup_frames` from `/etc/chissu-pam/config.toml` (falling back to `/usr/local/etc/chissu-pam/config.toml`) whenever the corresponding CLI flags are omitted. The command logs when it falls back to the built-in `/dev/video0`, `Y16`, and 4 warm-up frame defaults so operators can tell when config values are missing.

--- a/docs/users-guide/polkit-agent-helper-troubleshooting.md
+++ b/docs/users-guide/polkit-agent-helper-troubleshooting.md
@@ -1,0 +1,185 @@
+# Polkit Agent Helper Troubleshooting
+
+This guide covers `pam-chissu` failures that appear only when authentication is
+started through polkit-based desktop prompts, such as 1Password system unlock.
+The usual pattern is:
+
+- lock screen authentication works
+- `sudo` authentication works
+- 1Password or another polkit prompt falls back to password or fails
+
+On newer Linux desktop systems, `polkit-agent-helper@.service` may run with a
+strict systemd sandbox. That sandbox can hide the user session bus and camera
+device from the PAM module even after `pam_chissu` correctly drops privileges to
+the target user.
+
+## Confirm The Failure
+
+Inspect the PAM logs:
+
+```bash
+journalctl -t pam_chissu --since today --no-pager
+```
+
+You can also inspect the polkit helper unit:
+
+```bash
+systemctl cat polkit-agent-helper@.service
+```
+
+Look for sandboxing options such as:
+
+```ini
+ProtectHome=yes
+PrivateDevices=yes
+DevicePolicy=strict
+```
+
+These options are useful hardening, but they can block `pam_chissu` from reaching
+resources it needs for face authentication.
+
+## Secret Service Bus Is Blocked
+
+### Symptom
+
+The log contains a Secret Service or DBus error like:
+
+```text
+DBus session bus preflight failed for /run/user/1000/bus: Permission denied
+```
+
+or:
+
+```text
+Failed to connect to socket /run/user/1000/bus: Permission denied
+```
+
+This means `pam_chissu` recovered the correct session bus address, but the
+polkit helper service cannot access `/run/user/<uid>/bus`.
+
+### Recommended Override
+
+Create a systemd drop-in:
+
+```bash
+sudo systemctl edit polkit-agent-helper@.service
+```
+
+Add:
+
+```ini
+[Service]
+ProtectHome=tmpfs
+BindReadOnlyPaths=/run/user
+```
+
+Then reload systemd:
+
+```bash
+sudo systemctl daemon-reload
+systemctl cat polkit-agent-helper@.service
+```
+
+`ProtectHome=tmpfs` keeps `/home`, `/root`, and `/run/user` hidden by default.
+`BindReadOnlyPaths=/run/user` adds back the runtime directory needed to reach
+the user's session bus. The bus socket remains protected by normal Unix
+permissions, so the helper must still drop to the target user before it can use
+that user's bus.
+
+## Camera Device Is Hidden
+
+### Symptom
+
+After the Secret Service step succeeds, the log contains:
+
+```text
+Secret Service helper returned embedding key ... proceeding
+Failed to capture frame: failed to open video device /dev/videoX: No such file or directory
+```
+
+This usually means `PrivateDevices=yes` or `DevicePolicy=strict` hides the V4L2
+device from `polkit-agent-helper@.service`.
+
+### Recommended Override
+
+Add the configured camera device to the same drop-in. Replace `/dev/video2` with
+the `video_device` from `/etc/chissu-pam/config.toml`.
+
+```ini
+[Service]
+ProtectHome=tmpfs
+BindReadOnlyPaths=/run/user
+BindPaths=/dev/video2
+DeviceAllow=/dev/video2 rw
+```
+
+Reload systemd:
+
+```bash
+sudo systemctl daemon-reload
+systemctl cat polkit-agent-helper@.service
+```
+
+Retry the polkit flow, such as unlocking 1Password.
+
+## Broader Fallback
+
+If the device is still unavailable after `BindPaths=` and `DeviceAllow=`, the
+service may need a broader device namespace exception:
+
+```ini
+[Service]
+ProtectHome=tmpfs
+BindReadOnlyPaths=/run/user
+PrivateDevices=no
+DeviceAllow=/dev/video2 rw
+```
+
+Use this only after the narrower override fails. `PrivateDevices=no` exposes
+more of `/dev` to the polkit helper service.
+
+## Verification Checklist
+
+1. Confirm the effective unit contains your drop-in:
+
+   ```bash
+   systemctl cat polkit-agent-helper@.service
+   ```
+
+2. Confirm the camera path matches your config:
+
+   ```bash
+   rg '^video_device' /etc/chissu-pam/config.toml
+   ls -l /dev/video2
+   ```
+
+3. Retry the desktop prompt.
+
+4. Inspect `pam_chissu` logs:
+
+   ```bash
+   journalctl -t pam_chissu --since today --no-pager
+   ```
+
+Expected successful flow:
+
+```text
+Recovered Secret Service session environment from logind ...
+Secret Service helper returned embedding key ...
+Captured frame 1 from /dev/videoX ...
+Authentication success ...
+```
+
+## Security Notes
+
+These overrides relax the sandbox for `polkit-agent-helper@.service`.
+
+- `BindReadOnlyPaths=/run/user` lets the helper see user runtime directories.
+  Per-user directory permissions still restrict access to the target user's
+  session bus.
+- `BindPaths=/dev/videoX` and `DeviceAllow=/dev/videoX rw` expose the configured
+  camera device to the helper.
+- `PrivateDevices=no` is broader and should be treated as a last resort.
+
+Keep the override as narrow as your deployment allows, and prefer one specific
+camera device over exposing all video devices.

--- a/docs/users-guide/polkit-agent-helper-troubleshooting.md
+++ b/docs/users-guide/polkit-agent-helper-troubleshooting.md
@@ -27,6 +27,10 @@ You can also inspect the polkit helper unit:
 systemctl cat polkit-agent-helper@.service
 ```
 
+`chissu-cli doctor --polkit` performs the same read-only inspection and reports
+whether the effective sandbox appears to hide `/run/user` or the configured
+camera device.
+
 Look for sandboxing options such as:
 
 ```ini

--- a/openspec/specs/chissu-cli-doctor/spec.md
+++ b/openspec/specs/chissu-cli-doctor/spec.md
@@ -17,6 +17,14 @@ The doctor subcommand MUST validate runtime prerequisites, emit human-readable a
 - **AND** prints per-check statuses (`pass`/`warn`/`fail`) with reasons
 - **AND** returns exit code 0 only when all checks are `pass`, exits 1 otherwise.
 
+#### Scenario: Optional polkit helper sandbox diagnostics
+
+- **WHEN** an operator runs `chissu-cli doctor --polkit` (optionally with `--json`)
+- **THEN** the command appends read-only checks for `polkit-agent-helper@.service`
+- **AND** reports whether systemd sandbox settings may block `/run/user` Secret Service bus access
+- **AND** reports whether systemd sandbox settings may hide or deny the configured `video_device`
+- **AND** returns exit code 0 only when the standard and polkit checks are all `pass`.
+
 #### Scenario: Config files discovered and validated
 
 - **GIVEN** the shared config loader that searches `/etc/chissu-pam/config.toml` then `/usr/local/etc/chissu-pam/config.toml`

--- a/openspec/specs/pam-face-auth/spec.md
+++ b/openspec/specs/pam-face-auth/spec.md
@@ -60,6 +60,19 @@ Secret Service probing MUST execute in a helper that can impersonate the target 
 - **THEN** it MUST query `org.freedesktop.login1` for the target user's active session, extract the session's `Display` value and runtime directory, and provide those values (plus a synthesized `unix:path=${XDG_RUNTIME_DIR}/bus` address) to the helper before it contacts Secret Service
 - **SO THAT** Secret Service lookups succeed even when PAM is invoked from `polkit-1` or other non-graphical services where those environment variables are not inherited.
 
+#### Scenario: Helper selects X11 or Wayland session variables
+- **GIVEN** configuration sets `secret_service_session` to `auto`, `x11`, or `wayland` with `auto` as the default
+- **WHEN** the parent prepares the Secret Service helper environment from logind
+- **THEN** `auto` MUST prefer logind's `Type` and fall back to `Display` patterns (`wayland-*` for Wayland, `:N` for X11)
+- **AND** `x11` MUST export `DISPLAY` without `WAYLAND_DISPLAY`
+- **AND** `wayland` MUST export `WAYLAND_DISPLAY` without `DISPLAY`
+- **AND** every mode MUST export `XDG_RUNTIME_DIR` and `DBUS_SESSION_BUS_ADDRESS=unix:path=${XDG_RUNTIME_DIR}/bus` when logind or `/run/user/<uid>/bus` exposes a target-user runtime bus.
+
+#### Scenario: Helper overrides unusable DBus addresses
+- **WHEN** `$DBUS_SESSION_BUS_ADDRESS` is missing, empty, starts with `autolaunch:`, or points outside the target user's runtime bus
+- **THEN** the parent MUST override it with the target user's synthesized runtime bus address before the helper contacts Secret Service
+- **AND** it MUST log the configured mode, selected mode, logind session summary, and applied environment variable names without logging secret values.
+
 #### Scenario: Logind unreachable still surfaces structured errors
 - **WHEN** logind rejects the query, no active session is exposed for the user, or the runtime directory is missing
 - **THEN** the parent MUST log the structured reason (e.g., `no active logind session for user sett4`) and continue with the existing helper flow

--- a/scripts/lib/install_common.sh
+++ b/scripts/lib/install_common.sh
@@ -48,6 +48,8 @@ embedding_store_dir = "$store_dir"
 landmark_model = "$model_dir/$INSTALL_COMMON_LANDMARK_FILE"
 encoder_model = "$model_dir/$INSTALL_COMMON_ENCODER_FILE"
 require_secret_service = true
+# Secret Service session environment mode: "auto", "x11", or "wayland".
+secret_service_session = "auto"
 EOF_CFG
 }
 


### PR DESCRIPTION
## Summary
- Add an English troubleshooting guide for `polkit-agent-helper@.service` failures affecting 1Password/polkit prompts.
- Make Secret Service environment recovery session-aware with `auto`/`x11`/`wayland` config support.
- Harden PAM helper logging and preflight checks so bus and device failures are easier to diagnose.
- Update README, PAM docs, release notes, packaging defaults, and OpenSpec requirements to match the new behavior.

## Testing
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --workspace`
- `cargo test -p pam-chissu`